### PR TITLE
add pypi config and support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,18 +2,44 @@
 name = "temporal-mcp-server"
 version = "0.1.0"
 description = "MCP server for Temporal workflow orchestration"
+readme = "README.md"
+license = {text = "Apache-2.0"}
 requires-python = ">=3.10"
+authors = [
+    {name = "Mike", email = "mike@miketoscano.com"},
+]
+keywords = ["temporal", "mcp", "model-context-protocol", "workflow", "orchestration"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries",
+]
 dependencies = [
     "temporalio>=1.5.0",
     "mcp>=0.9.0",
+    "asyncio-atexit>=1.0.1",
 ]
+
+[project.urls]
+Homepage = "https://github.com/GethosTheWalrus/temporal-mcp"
+Repository = "https://github.com/GethosTheWalrus/temporal-mcp"
+Issues = "https://github.com/GethosTheWalrus/temporal-mcp/issues"
+
+[project.scripts]
+temporal-mcp-server = "temporal_mcp.__main__:main"
 
 [build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-packages = ["temporal_mcp"]
+[tool.setuptools.packages.find]
+include = ["temporal_mcp*"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/server.py
+++ b/server.py
@@ -1,35 +1,11 @@
-"""Entry point for Temporal MCP Server."""
+"""Entry point for Temporal MCP Server (Docker / standalone use).
 
-import asyncio
-import os
-import sys
+For pip-installed usage, prefer:
+  temporal-mcp-server        (CLI)
+  python -m temporal_mcp     (module)
+"""
 
-from temporal_mcp.server import TemporalMCPServer
-
-
-async def main():
-    """Main entry point for the MCP server."""
-    temporal_host = os.environ.get("TEMPORAL_HOST", "localhost:7233")
-    namespace = os.environ.get("TEMPORAL_NAMESPACE", "default")
-    
-    # Parse TLS setting: None (auto-detect), True (force enable), False (force disable)
-    tls_env = os.environ.get("TEMPORAL_TLS_ENABLED", "").lower()
-    if tls_env == "true":
-        tls_enabled = True
-    elif tls_env == "false":
-        tls_enabled = False
-    else:
-        tls_enabled = None  # Auto-detect
-    
-    print(f"Starting MCP server with TEMPORAL_HOST={temporal_host}, TLS={tls_enabled}", file=sys.stderr)
-    
-    server = TemporalMCPServer(
-        temporal_host=temporal_host,
-        namespace=namespace,
-        tls_enabled=tls_enabled
-    )
-    await server.run()
-
+from temporal_mcp.__main__ import main
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()

--- a/temporal_mcp/__main__.py
+++ b/temporal_mcp/__main__.py
@@ -1,0 +1,43 @@
+"""Entry point for Temporal MCP Server.
+
+Supports:
+  - `python -m temporal_mcp`
+  - `temporal-mcp-server` CLI (installed via pip)
+"""
+
+import asyncio
+import os
+import sys
+
+from temporal_mcp.server import TemporalMCPServer
+
+
+def main():
+    """Main entry point for the MCP server."""
+    temporal_host = os.environ.get("TEMPORAL_HOST", "localhost:7233")
+    namespace = os.environ.get("TEMPORAL_NAMESPACE", "default")
+
+    # Parse TLS setting: None (auto-detect), True (force enable), False (force disable)
+    tls_env = os.environ.get("TEMPORAL_TLS_ENABLED", "").lower()
+    if tls_env == "true":
+        tls_enabled = True
+    elif tls_env == "false":
+        tls_enabled = False
+    else:
+        tls_enabled = None  # Auto-detect
+
+    print(
+        f"Starting MCP server with TEMPORAL_HOST={temporal_host}, TLS={tls_enabled}",
+        file=sys.stderr,
+    )
+
+    server = TemporalMCPServer(
+        temporal_host=temporal_host,
+        namespace=namespace,
+        tls_enabled=tls_enabled,
+    )
+    asyncio.run(server.run())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add PyPI package support
Publishes temporal-mcp-server to PyPI, giving users a pip/uvx installation path alongside the existing Docker image.

Changes
pyproject.toml

Added full package metadata: author, license, readme, keywords, classifiers, and project URLs
Added missing asyncio-atexit dependency
Registered the temporal-mcp-server CLI entry point pointing to temporal_mcp.__main__:main
Switched from [tool.setuptools] packages to [tool.setuptools.packages.find] with include = ["temporal_mcp*"] so sub-packages (handlers, tools, utils) are correctly bundled
__main__.py (new)

Moved server startup logic into a proper main() function inside the package
Supports three invocation methods: temporal-mcp-server CLI, python -m temporal_mcp, and direct execution of server.py
server.py

Slimmed down to a thin shim that delegates to temporal_mcp.__main__:main, keeping backwards compatibility for anyone running it directly
Usage (after this PR)

```
{
  "servers": {
    "temporal": {
      "command": "uvx",
      "args": ["temporal-mcp-server==0.1.0"],
      "env": {
        "TEMPORAL_HOST": "localhost:7233",
        "TEMPORAL_NAMESPACE": "default",
        "TEMPORAL_TLS_ENABLED": "false"
      }
    }
  }
}
```
