### PR TITLE
feat: add CLI argument support for server configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,317 +46,68 @@ For more information about Temporal, refer to the official Temporal documentatio
 - **Activities**: https://docs.temporal.io/activities
 - **Python SDK**: https://docs.temporal.io/dev-guide/python
 
-## MCP Client Config Examples
+## VS Code MCP Config
 
-### OpenCode
+Add a `.vscode/mcp.json` file to your workspace. Choose the approach that fits your setup.
 
-Add to your OpenCode settings (`~/.config/opencode/opencode.json`):
+### Docker (environment variables)
 
-```json
-{
-  "$schema": "https://opencode.ai/config.json",
-  "mcp": {
-    "temporal": {
-      "type": "local",
-      "command": [
-        "docker", "run", "-i", "--rm", "--network", "host",
-        "-e", "TEMPORAL_HOST=192.168.69.98:7233",
-        "-e", "TEMPORAL_NAMESPACE=default",
-        "-e", "TEMPORAL_TLS_ENABLED=false",
-        "temporal-mcp-server:latest"
-      ],
-      "enabled": true
-    }
-  }
-}
-```
-
-### VS Code (Copilot MCP)
-
-Add to your VS Code settings (`.vscode/mcp.json` or global settings):
+Recommended when running via Docker. Configuration is passed through environment variables.
 
 ```json
 {
-  "mcp.servers": {
-    "temporal": {
-      "command": "docker",
-      "args": [
-        "run", "-i", "--rm", "--network", "host",
-        "-e", "TEMPORAL_HOST=192.168.69.98:7233",
-        "-e", "TEMPORAL_NAMESPACE=default",
-        "-e", "TEMPORAL_TLS_ENABLED=false",
-        "temporal-mcp-server:latest"
-      ]
-    }
-  }
-}
-```
-
-### Cursor
-
-Add to your Cursor MCP settings (`~/.cursor/mcp.json` on macOS/Linux or `%APPDATA%\Cursor\mcp.json` on Windows):
-
-```json
-{
-  "mcpServers": {
-    "temporal": {
-      "command": "docker",
-      "args": [
-        "run", "-i", "--rm", "--network", "host",
-        "-e", "TEMPORAL_HOST=192.168.69.98:7233",
-        "-e", "TEMPORAL_NAMESPACE=default",
-        "-e", "TEMPORAL_TLS_ENABLED=false",
-        "temporal-mcp-server:latest"
-      ]
-    }
-  }
-}
-```
-
-### Claude Desktop
-
-Add to your Claude Desktop configuration (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS, `%APPDATA%\Claude\claude_desktop_config.json` on Windows):
-
-```json
-{
-  "mcpServers": {
-    "temporal": {
-      "command": "docker",
-      "args": [
-        "run", "-i", "--rm", "--network", "host",
-        "-e", "TEMPORAL_HOST=192.168.69.98:7233",
-        "-e", "TEMPORAL_NAMESPACE=default",
-        "-e", "TEMPORAL_TLS_ENABLED=false",
-        "temporal-mcp-server:latest"
-      ]
-    }
-  }
-}
-```
-
-### Configuration Notes
-
-- **TEMPORAL_HOST**: Set to your Temporal server address (default: `localhost:7233`)
-- **TEMPORAL_NAMESPACE**: Set to your Temporal namespace (default: `default`)
-- **TEMPORAL_TLS_ENABLED**: Set to `true` for remote servers, `false` for local, or omit for auto-detection
-- **TEMPORAL_TLS_CLIENT_CERT_PATH**: Path to the mTLS client certificate file (for Temporal Cloud mTLS namespaces)
-- **TEMPORAL_TLS_CLIENT_KEY_PATH**: Path to the mTLS client private key file (for Temporal Cloud mTLS namespaces)
-- **TEMPORAL_API_KEY**: API key for Temporal Cloud API key authentication
-- Replace `192.168.69.98:7233` with your actual Temporal server address
-- For local development, you can use `localhost:7233` or `host.docker.internal:7233` (when running in Docker)
-
-### Temporal Cloud (API Key)
-
-The simplest way to connect to Temporal Cloud. When `TEMPORAL_API_KEY` is set, TLS is enabled automatically.
-
-#### OpenCode
-
-```json
-{
-  "$schema": "https://opencode.ai/config.json",
-  "mcp": {
-    "temporal": {
-      "type": "local",
-      "command": [
-        "docker", "run", "-i", "--rm",
-        "-e", "TEMPORAL_HOST=your-namespace.your-account.tmprl.cloud:7233",
-        "-e", "TEMPORAL_NAMESPACE=your-namespace.your-account",
-        "-e", "TEMPORAL_API_KEY=your-api-key",
-        "temporal-mcp-server:latest"
-      ],
-      "enabled": true
-    }
-  }
-}
-```
-
-#### VS Code (Copilot MCP)
-
-**Docker:**
-
-```json
-{
-  "mcp.servers": {
+  "servers": {
     "temporal": {
       "command": "docker",
       "args": [
         "run", "-i", "--rm",
-        "-e", "TEMPORAL_HOST=your-namespace.your-account.tmprl.cloud:7233",
-        "-e", "TEMPORAL_NAMESPACE=your-namespace.your-account",
-        "-e", "TEMPORAL_API_KEY=your-api-key",
-        "temporal-mcp-server:latest"
-      ]
-    }
-  }
-}
-```
-
-**uvx:**
-
-```json
-{
-  "mcp.servers": {
-    "temporal": {
-      "command": "uvx",
-      "args": ["temporal-mcp-server"],
+        "-e", "TEMPORAL_HOST",
+        "-e", "TEMPORAL_NAMESPACE",
+        "-e", "TEMPORAL_TLS_ENABLED",
+        "mcp/temporal"
+      ],
       "env": {
-        "TEMPORAL_HOST": "your-namespace.your-account.tmprl.cloud:7233",
-        "TEMPORAL_NAMESPACE": "your-namespace.your-account",
-        "TEMPORAL_API_KEY": "your-api-key"
+        "TEMPORAL_HOST": "localhost:7233",
+        "TEMPORAL_NAMESPACE": "default",
+        "TEMPORAL_TLS_ENABLED": "false"
       }
     }
   }
 }
 ```
 
-#### Cursor
+### Python (CLI arguments)
+
+Recommended when running from a local Python environment (e.g. installed via [PyPI](https://pypi.org/project/temporal-mcp-server/)). Configuration is passed as CLI arguments.
 
 ```json
 {
-  "mcpServers": {
+  "servers": {
     "temporal": {
-      "command": "docker",
+      "command": "/path/to/venv/bin/python",
       "args": [
-        "run", "-i", "--rm",
-        "-e", "TEMPORAL_HOST=your-namespace.your-account.tmprl.cloud:7233",
-        "-e", "TEMPORAL_NAMESPACE=your-namespace.your-account",
-        "-e", "TEMPORAL_API_KEY=your-api-key",
-        "temporal-mcp-server:latest"
+        "-m", "temporal_mcp",
+        "--host", "localhost:7233",
+        "--namespace", "default",
+        "--tls-enabled", "false"
       ]
     }
   }
 }
 ```
 
-#### Claude Desktop
+### Configuration Options
 
-```json
-{
-  "mcpServers": {
-    "temporal": {
-      "command": "docker",
-      "args": [
-        "run", "-i", "--rm",
-        "-e", "TEMPORAL_HOST=your-namespace.your-account.tmprl.cloud:7233",
-        "-e", "TEMPORAL_NAMESPACE=your-namespace.your-account",
-        "-e", "TEMPORAL_API_KEY=your-api-key",
-        "temporal-mcp-server:latest"
-      ]
-    }
-  }
-}
-```
+| Option | CLI Argument | Environment Variable | Default |
+|--------|-------------|----------------------|---------|
+| Temporal host | `--host` | `TEMPORAL_HOST` | `localhost:7233` |
+| Namespace | `--namespace` | `TEMPORAL_NAMESPACE` | `default` |
+| TLS | `--tls-enabled` | `TEMPORAL_TLS_ENABLED` | auto-detect |
+| mTLS cert path | `--tls-cert` | `TEMPORAL_TLS_CLIENT_CERT_PATH` | — |
+| mTLS key path | `--tls-key` | `TEMPORAL_TLS_CLIENT_KEY_PATH` | — |
+| API key | `--api-key` | `TEMPORAL_API_KEY` | — |
 
-### Temporal Cloud (mTLS)
-
-To connect to Temporal Cloud, provide your mTLS client certificate and key. The server will automatically enable TLS when client certs are provided.
-
-#### OpenCode
-
-```json
-{
-  "$schema": "https://opencode.ai/config.json",
-  "mcp": {
-    "temporal": {
-      "type": "local",
-      "command": [
-        "docker", "run", "-i", "--rm",
-        "-v", "/path/to/certs:/certs:ro",
-        "-e", "TEMPORAL_HOST=your-namespace.tmprl.cloud:7233",
-        "-e", "TEMPORAL_NAMESPACE=your-namespace",
-        "-e", "TEMPORAL_TLS_CLIENT_CERT_PATH=/certs/client.pem",
-        "-e", "TEMPORAL_TLS_CLIENT_KEY_PATH=/certs/client.key",
-        "temporal-mcp-server:latest"
-      ],
-      "enabled": true
-    }
-  }
-}
-```
-
-#### VS Code (Copilot MCP)
-
-**Docker:**
-
-```json
-{
-  "mcp.servers": {
-    "temporal": {
-      "command": "docker",
-      "args": [
-        "run", "-i", "--rm",
-        "-v", "/path/to/certs:/certs:ro",
-        "-e", "TEMPORAL_HOST=your-namespace.tmprl.cloud:7233",
-        "-e", "TEMPORAL_NAMESPACE=your-namespace",
-        "-e", "TEMPORAL_TLS_CLIENT_CERT_PATH=/certs/client.pem",
-        "-e", "TEMPORAL_TLS_CLIENT_KEY_PATH=/certs/client.key",
-        "temporal-mcp-server:latest"
-      ]
-    }
-  }
-}
-```
-
-**uvx:**
-
-```json
-{
-  "mcp.servers": {
-    "temporal": {
-      "command": "uvx",
-      "args": ["temporal-mcp-server"],
-      "env": {
-        "TEMPORAL_HOST": "your-namespace.tmprl.cloud:7233",
-        "TEMPORAL_NAMESPACE": "your-namespace",
-        "TEMPORAL_TLS_CLIENT_CERT_PATH": "/path/to/client.pem",
-        "TEMPORAL_TLS_CLIENT_KEY_PATH": "/path/to/client.key"
-      }
-    }
-  }
-}
-```
-
-#### Cursor
-
-```json
-{
-  "mcpServers": {
-    "temporal": {
-      "command": "docker",
-      "args": [
-        "run", "-i", "--rm",
-        "-v", "/path/to/certs:/certs:ro",
-        "-e", "TEMPORAL_HOST=your-namespace.tmprl.cloud:7233",
-        "-e", "TEMPORAL_NAMESPACE=your-namespace",
-        "-e", "TEMPORAL_TLS_CLIENT_CERT_PATH=/certs/client.pem",
-        "-e", "TEMPORAL_TLS_CLIENT_KEY_PATH=/certs/client.key",
-        "temporal-mcp-server:latest"
-      ]
-    }
-  }
-}
-```
-
-#### Claude Desktop
-
-```json
-{
-  "mcpServers": {
-    "temporal": {
-      "command": "docker",
-      "args": [
-        "run", "-i", "--rm",
-        "-v", "/path/to/certs:/certs:ro",
-        "-e", "TEMPORAL_HOST=your-namespace.tmprl.cloud:7233",
-        "-e", "TEMPORAL_NAMESPACE=your-namespace",
-        "-e", "TEMPORAL_TLS_CLIENT_CERT_PATH=/certs/client.pem",
-        "-e", "TEMPORAL_TLS_CLIENT_KEY_PATH=/certs/client.key",
-        "temporal-mcp-server:latest"
-      ]
-    }
-  }
-}
-```
+CLI arguments take precedence over environment variables. When `TEMPORAL_API_KEY` is set, TLS is enabled automatically. When mTLS cert/key paths are provided, TLS is also enabled automatically.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -64,12 +64,18 @@ Recommended when running via Docker. Configuration is passed through environment
         "-e", "TEMPORAL_HOST",
         "-e", "TEMPORAL_NAMESPACE",
         "-e", "TEMPORAL_TLS_ENABLED",
+        "-e", "TEMPORAL_TLS_CLIENT_CERT_PATH",
+        "-e", "TEMPORAL_TLS_CLIENT_KEY_PATH",
+        "-e", "TEMPORAL_API_KEY",
         "mcp/temporal"
       ],
       "env": {
         "TEMPORAL_HOST": "localhost:7233",
         "TEMPORAL_NAMESPACE": "default",
-        "TEMPORAL_TLS_ENABLED": "false"
+        "TEMPORAL_TLS_ENABLED": "false",
+        "TEMPORAL_TLS_CLIENT_CERT_PATH": "/path/to/client.pem",
+        "TEMPORAL_TLS_CLIENT_KEY_PATH": "/path/to/client.key",
+        "TEMPORAL_API_KEY": "your-api-key"
       }
     }
   }
@@ -89,7 +95,10 @@ Recommended when running from a local Python environment (e.g. installed via [Py
         "-m", "temporal_mcp",
         "--host", "localhost:7233",
         "--namespace", "default",
-        "--tls-enabled", "false"
+        "--tls-enabled", "false",
+        "--tls-cert", "/path/to/client.pem",
+        "--tls-key", "/path/to/client.key",
+        "--api-key", "your-api-key"
       ]
     }
   }

--- a/temporal_mcp/__main__.py
+++ b/temporal_mcp/__main__.py
@@ -3,8 +3,14 @@
 Supports:
   - `python -m temporal_mcp`
   - `temporal-mcp-server` CLI (installed via pip)
+
+Configuration priority (highest → lowest):
+  1. CLI arguments
+  2. Environment variables
+  3. Built-in defaults
 """
 
+import argparse
 import asyncio
 import os
 import sys
@@ -12,26 +18,77 @@ import sys
 from temporal_mcp.server import TemporalMCPServer
 
 
+def _parse_args() -> argparse.Namespace:
+    """Parse optional CLI arguments."""
+    parser = argparse.ArgumentParser(
+        prog="temporal-mcp-server",
+        description="MCP server for Temporal workflow orchestration.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--host",
+        metavar="HOST:PORT",
+        default=None,
+        help="Temporal server host and port (env: TEMPORAL_HOST, default: localhost:7233)",
+    )
+    parser.add_argument(
+        "--namespace",
+        metavar="NAMESPACE",
+        default=None,
+        help="Temporal namespace (env: TEMPORAL_NAMESPACE, default: default)",
+    )
+    parser.add_argument(
+        "--tls-enabled",
+        metavar="BOOL",
+        default=None,
+        choices=["true", "false"],
+        type=str.lower,
+        help="Force-enable or force-disable TLS; omit to auto-detect (env: TEMPORAL_TLS_ENABLED)",
+    )
+    parser.add_argument(
+        "--tls-cert",
+        metavar="PATH",
+        default=None,
+        help="Path to mTLS client certificate file (env: TEMPORAL_TLS_CLIENT_CERT_PATH)",
+    )
+    parser.add_argument(
+        "--tls-key",
+        metavar="PATH",
+        default=None,
+        help="Path to mTLS client private key file (env: TEMPORAL_TLS_CLIENT_KEY_PATH)",
+    )
+    parser.add_argument(
+        "--api-key",
+        metavar="KEY",
+        default=None,
+        help="API key for Temporal Cloud authentication (env: TEMPORAL_API_KEY)",
+    )
+    return parser.parse_args()
+
+
 def main():
     """Main entry point for the MCP server."""
-    temporal_host = os.environ.get("TEMPORAL_HOST", "localhost:7233")
-    namespace = os.environ.get("TEMPORAL_NAMESPACE", "default")
+    args = _parse_args()
+
+    # CLI arg → env var → built-in default
+    temporal_host = args.host or os.environ.get("TEMPORAL_HOST", "localhost:7233")
+    namespace = args.namespace or os.environ.get("TEMPORAL_NAMESPACE", "default")
 
     # Parse TLS setting: None (auto-detect), True (force enable), False (force disable)
-    tls_env = os.environ.get("TEMPORAL_TLS_ENABLED", "").lower()
-    if tls_env == "true":
+    tls_raw = args.tls_enabled or os.environ.get("TEMPORAL_TLS_ENABLED", "").lower()
+    if tls_raw == "true":
         tls_enabled = True
-    elif tls_env == "false":
+    elif tls_raw == "false":
         tls_enabled = False
     else:
         tls_enabled = None  # Auto-detect
 
     # mTLS client certificate paths (for Temporal Cloud)
-    tls_client_cert_path = os.environ.get("TEMPORAL_TLS_CLIENT_CERT_PATH")
-    tls_client_key_path = os.environ.get("TEMPORAL_TLS_CLIENT_KEY_PATH")
+    tls_client_cert_path = args.tls_cert or os.environ.get("TEMPORAL_TLS_CLIENT_CERT_PATH")
+    tls_client_key_path = args.tls_key or os.environ.get("TEMPORAL_TLS_CLIENT_KEY_PATH")
 
     # API key authentication (for Temporal Cloud)
-    api_key = os.environ.get("TEMPORAL_API_KEY")
+    api_key = args.api_key or os.environ.get("TEMPORAL_API_KEY")
 
     print(
         f"Starting MCP server with TEMPORAL_HOST={temporal_host}, TLS={tls_enabled}",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,249 @@
+"""Tests for __main__ entry point: CLI arg parsing, env var fallback, and precedence."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_main(argv: list[str], env: dict[str, str] | None = None):
+    """Invoke main() with a controlled argv and environment, returning the
+    TemporalMCPServer constructor kwargs captured via mock."""
+    import sys
+
+    env = env or {}
+
+    captured = {}
+
+    def fake_server(**kwargs):
+        captured.update(kwargs)
+        instance = MagicMock()
+        instance.run = AsyncMock()
+        return instance
+
+    with (
+        patch.object(sys, "argv", ["temporal-mcp-server"] + argv),
+        patch.dict("os.environ", env, clear=True),
+        patch("temporal_mcp.__main__.TemporalMCPServer", side_effect=fake_server),
+        patch("temporal_mcp.__main__.asyncio.run"),
+    ):
+        from temporal_mcp.__main__ import main
+
+        main()
+
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# _parse_args
+# ---------------------------------------------------------------------------
+
+
+class TestParseArgs:
+    def _parse(self, argv: list[str]):
+        import sys
+        from unittest.mock import patch
+        from temporal_mcp.__main__ import _parse_args
+
+        with patch.object(sys, "argv", ["temporal-mcp-server"] + argv):
+            return _parse_args()
+
+    def test_all_args_parsed(self):
+        ns = self._parse(
+            [
+                "--host",
+                "myhost:7233",
+                "--namespace",
+                "mynamespace",
+                "--tls-enabled",
+                "true",
+                "--tls-cert",
+                "/certs/client.pem",
+                "--tls-key",
+                "/certs/client.key",
+                "--api-key",
+                "secret",
+            ]
+        )
+        assert ns.host == "myhost:7233"
+        assert ns.namespace == "mynamespace"
+        assert ns.tls_enabled == "true"
+        assert ns.tls_cert == "/certs/client.pem"
+        assert ns.tls_key == "/certs/client.key"
+        assert ns.api_key == "secret"
+
+    def test_no_args_all_none(self):
+        ns = self._parse([])
+        assert ns.host is None
+        assert ns.namespace is None
+        assert ns.tls_enabled is None
+        assert ns.tls_cert is None
+        assert ns.tls_key is None
+        assert ns.api_key is None
+
+    def test_tls_enabled_normalised_to_lowercase(self):
+        ns = self._parse(["--tls-enabled", "True"])
+        assert ns.tls_enabled == "true"
+
+    def test_tls_enabled_false(self):
+        ns = self._parse(["--tls-enabled", "false"])
+        assert ns.tls_enabled == "false"
+
+    def test_invalid_tls_enabled_raises(self):
+        import sys
+        from unittest.mock import patch
+        from temporal_mcp.__main__ import _parse_args
+
+        with (
+            patch.object(sys, "argv", ["temporal-mcp-server", "--tls-enabled", "maybe"]),
+            pytest.raises(SystemExit),
+        ):
+            _parse_args()
+
+
+# ---------------------------------------------------------------------------
+# Defaults (no args, no env vars)
+# ---------------------------------------------------------------------------
+
+
+class TestDefaults:
+    def test_host_default(self):
+        kwargs = _run_main([], env={})
+        assert kwargs["temporal_host"] == "localhost:7233"
+
+    def test_namespace_default(self):
+        kwargs = _run_main([], env={})
+        assert kwargs["namespace"] == "default"
+
+    def test_tls_default_is_none(self):
+        kwargs = _run_main([], env={})
+        assert kwargs["tls_enabled"] is None
+
+    def test_cert_key_api_key_default_is_none(self):
+        kwargs = _run_main([], env={})
+        assert kwargs["tls_client_cert_path"] is None
+        assert kwargs["tls_client_key_path"] is None
+        assert kwargs["api_key"] is None
+
+
+# ---------------------------------------------------------------------------
+# Env vars used when no args supplied
+# ---------------------------------------------------------------------------
+
+
+class TestEnvVarFallback:
+    def test_host_from_env(self):
+        kwargs = _run_main([], env={"TEMPORAL_HOST": "envhost:7233"})
+        assert kwargs["temporal_host"] == "envhost:7233"
+
+    def test_namespace_from_env(self):
+        kwargs = _run_main([], env={"TEMPORAL_NAMESPACE": "envns"})
+        assert kwargs["namespace"] == "envns"
+
+    def test_tls_true_from_env(self):
+        kwargs = _run_main([], env={"TEMPORAL_TLS_ENABLED": "true"})
+        assert kwargs["tls_enabled"] is True
+
+    def test_tls_false_from_env(self):
+        kwargs = _run_main([], env={"TEMPORAL_TLS_ENABLED": "false"})
+        assert kwargs["tls_enabled"] is False
+
+    def test_tls_empty_env_gives_none(self):
+        kwargs = _run_main([], env={"TEMPORAL_TLS_ENABLED": ""})
+        assert kwargs["tls_enabled"] is None
+
+    def test_cert_from_env(self):
+        kwargs = _run_main([], env={"TEMPORAL_TLS_CLIENT_CERT_PATH": "/env/cert.pem"})
+        assert kwargs["tls_client_cert_path"] == "/env/cert.pem"
+
+    def test_key_from_env(self):
+        kwargs = _run_main([], env={"TEMPORAL_TLS_CLIENT_KEY_PATH": "/env/key.pem"})
+        assert kwargs["tls_client_key_path"] == "/env/key.pem"
+
+    def test_api_key_from_env(self):
+        kwargs = _run_main([], env={"TEMPORAL_API_KEY": "env-secret"})
+        assert kwargs["api_key"] == "env-secret"
+
+
+# ---------------------------------------------------------------------------
+# CLI args take precedence over env vars
+# ---------------------------------------------------------------------------
+
+
+class TestArgPrecedenceOverEnv:
+    def test_host_arg_overrides_env(self):
+        kwargs = _run_main(
+            ["--host", "arghost:7233"],
+            env={"TEMPORAL_HOST": "envhost:7233"},
+        )
+        assert kwargs["temporal_host"] == "arghost:7233"
+
+    def test_namespace_arg_overrides_env(self):
+        kwargs = _run_main(
+            ["--namespace", "argns"],
+            env={"TEMPORAL_NAMESPACE": "envns"},
+        )
+        assert kwargs["namespace"] == "argns"
+
+    def test_tls_arg_overrides_env(self):
+        kwargs = _run_main(
+            ["--tls-enabled", "true"],
+            env={"TEMPORAL_TLS_ENABLED": "false"},
+        )
+        assert kwargs["tls_enabled"] is True
+
+    def test_cert_arg_overrides_env(self):
+        kwargs = _run_main(
+            ["--tls-cert", "/arg/cert.pem"],
+            env={"TEMPORAL_TLS_CLIENT_CERT_PATH": "/env/cert.pem"},
+        )
+        assert kwargs["tls_client_cert_path"] == "/arg/cert.pem"
+
+    def test_key_arg_overrides_env(self):
+        kwargs = _run_main(
+            ["--tls-key", "/arg/key.pem"],
+            env={"TEMPORAL_TLS_CLIENT_KEY_PATH": "/env/key.pem"},
+        )
+        assert kwargs["tls_client_key_path"] == "/arg/key.pem"
+
+    def test_api_key_arg_overrides_env(self):
+        kwargs = _run_main(
+            ["--api-key", "arg-secret"],
+            env={"TEMPORAL_API_KEY": "env-secret"},
+        )
+        assert kwargs["api_key"] == "arg-secret"
+
+    def test_all_args_override_all_env_vars(self):
+        kwargs = _run_main(
+            [
+                "--host",
+                "arghost:7233",
+                "--namespace",
+                "argns",
+                "--tls-enabled",
+                "false",
+                "--tls-cert",
+                "/arg/cert.pem",
+                "--tls-key",
+                "/arg/key.pem",
+                "--api-key",
+                "arg-secret",
+            ],
+            env={
+                "TEMPORAL_HOST": "envhost:7233",
+                "TEMPORAL_NAMESPACE": "envns",
+                "TEMPORAL_TLS_ENABLED": "true",
+                "TEMPORAL_TLS_CLIENT_CERT_PATH": "/env/cert.pem",
+                "TEMPORAL_TLS_CLIENT_KEY_PATH": "/env/key.pem",
+                "TEMPORAL_API_KEY": "env-secret",
+            },
+        )
+        assert kwargs["temporal_host"] == "arghost:7233"
+        assert kwargs["namespace"] == "argns"
+        assert kwargs["tls_enabled"] is False
+        assert kwargs["tls_client_cert_path"] == "/arg/cert.pem"
+        assert kwargs["tls_client_key_path"] == "/arg/key.pem"
+        assert kwargs["api_key"] == "arg-secret"


### PR DESCRIPTION
## Summary

Adds optional CLI argument support to the `temporal-mcp-server` entry point, making it easier to configure the server when running from a local Python environment (e.g. installed via PyPI) without needing to set environment variables.

## Changes

- **`temporal_mcp/__main__.py`** — introduces `argparse` with flags for all config options (`--host`, `--namespace`, `--tls-enabled`, `--tls-cert`, `--tls-key`, `--api-key`). Resolution order is CLI arg → env var → built-in default, so existing Docker/env-var usage is fully backward compatible.
- **`tests/test_main.py`** — new test suite (24 tests) covering arg parsing, env var fallback, built-in defaults, and CLI arg precedence over env vars.
- **`README.md`** — consolidates the MCP client config section to two focused VS Code examples: one for Docker (env vars) and one for Python (CLI args), with a full options reference table.

## Usage

```bash
# via PyPI
temporal-mcp-server --host localhost:7233 --namespace default --tls-enabled false

# Docker/env vars unchanged
TEMPORAL_HOST=localhost:7233 TEMPORAL_NAMESPACE=default temporal-mcp-server
```