### PR TITLE
ci: fix PyPI publish not triggering after semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    name: Semantic release
+    name: Semantic release and publish
     runs-on: ubuntu-latest
     concurrency: release
     permissions:
@@ -26,10 +26,29 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install python-semantic-release
-        run: pip install python-semantic-release
+      - name: Install tools
+        run: pip install python-semantic-release build
+
+      - name: Check for releasable commits
+        id: version_check
+        run: |
+          version=$(semantic-release version --print 2>/dev/null || true)
+          if [ -n "$version" ]; then
+            echo "will_release=true" >> $GITHUB_OUTPUT
+          else
+            echo "will_release=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Run semantic release
+        if: steps.version_check.outputs.will_release == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: semantic-release version --push
+
+      - name: Build package
+        if: steps.version_check.outputs.will_release == 'true'
+        run: python -m build
+
+      - name: Publish to PyPI
+        if: steps.version_check.outputs.will_release == 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Problem

The `publish.yml` workflow was never triggered for `v1.0.1` or `v1.1.0`. GitHub Actions does not fire workflow events for tag pushes made by `GITHUB_TOKEN`, so the tag created by `release.yml` never triggered `publish.yml`.

## Fix

Consolidate the build and publish steps directly into `release.yml`, eliminating the cross-workflow trigger dependency entirely. A `version_check` step runs `semantic-release version --print` first; the release, build, and publish steps are all gated on its output so they're skipped cleanly when there are no releasable commits.

The standalone `publish.yml` can be removed in a follow-up once this is confirmed working.