### PR TITLE
ci: fix PyPI publish not triggering after semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,13 @@ on:
 
 jobs:
   release:
-    name: Semantic release and publish
+    name: Semantic release
     runs-on: ubuntu-latest
     concurrency: release
     permissions:
-      id-token: write
       contents: write
+    outputs:
+      released: ${{ steps.version_check.outputs.will_release }}
 
     steps:
       - name: Checkout
@@ -49,6 +50,28 @@ jobs:
         if: steps.version_check.outputs.will_release == 'true'
         run: python -m build
 
-      - name: Publish to PyPI
+      - name: Upload build artifacts
         if: steps.version_check.outputs.will_release == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Problem

`GITHUB_TOKEN`-triggered tag pushes don't fire other workflow events, so `publish.yml` was never triggered for `v1.0.1` or `v1.1.0`. Additionally, OIDC trusted publishing requires an `environment` claim, which was missing from the previous attempt.

## Fix

- Splits `release.yml` into two jobs: `release` (semantic versioning + build) and `publish` (PyPI upload)
- The `publish` job uses `environment: pypi`, satisfying the OIDC trusted publisher claim
- The dist artifact is passed between jobs via `actions/upload-artifact` / `actions/download-artifact`
- Both downstream steps are gated on a `released` output from the `release` job, so they're skipped when there are no releasable commits

> The trusted publisher on PyPI has been updated to reference `release.yml` with environment `pypi`.