### PR TITLE
feat: add describe_schedule tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Read more on the [Temporal Code Exchange](https://temporal.io/code-exchange/temp
 
 - **`create_schedule`** - Create a new schedule for periodic workflow execution using cron expressions
 - **`list_schedules`** - List all schedules with pagination support (limit/skip)
+- **`describe_schedule`** - Get detailed configuration and runtime information about a schedule, including its spec, action, state, recent executions, and upcoming action times
 - **`pause_schedule`** - Pause a schedule to temporarily stop workflow executions
 - **`unpause_schedule`** - Resume a paused schedule
 - **`delete_schedule`** - Permanently delete a schedule

--- a/temporal_mcp/handlers/schedule_handlers.py
+++ b/temporal_mcp/handlers/schedule_handlers.py
@@ -4,7 +4,7 @@ import json
 import sys
 
 from mcp.types import TextContent
-from temporalio.client import Client, Schedule, ScheduleActionStartWorkflow, ScheduleSpec
+from temporalio.client import Client, Schedule, ScheduleActionStartWorkflow, ScheduleSpec, ScheduleDescription
 
 
 async def create_schedule(client: Client, args: dict) -> list[TextContent]:
@@ -171,3 +171,65 @@ async def trigger_schedule(client: Client, args: dict) -> list[TextContent]:
     await handle.trigger()
 
     return [TextContent(type="text", text=json.dumps({"status": "triggered", "schedule_id": schedule_id}, indent=2))]
+
+
+async def describe_schedule(client: Client, args: dict) -> list[TextContent]:
+    """Retrieve configuration and runtime information about a schedule.
+
+    Args:
+        client: Connected Temporal client
+        args: Arguments containing schedule_id
+
+    Returns:
+        Schedule description including spec, state, and recent execution info
+    """
+    schedule_id = args["schedule_id"]
+
+    handle = client.get_schedule_handle(schedule_id)
+    desc: ScheduleDescription = await handle.describe()
+
+    sched = desc.schedule
+    info = desc.info
+
+    action_info: dict = {}
+    if isinstance(sched.action, ScheduleActionStartWorkflow):
+        action_info = {
+            "workflow": sched.action.workflow,
+            "task_queue": sched.action.task_queue,
+            "workflow_execution_id": sched.action.id,
+        }
+
+    recent_actions = [
+        {
+            "scheduled_at": r.scheduled_at.isoformat(),
+            "started_at": r.started_at.isoformat(),
+        }
+        for r in info.recent_actions
+    ]
+
+    next_action_times = [t.isoformat() for t in info.next_action_times]
+
+    result = {
+        "schedule_id": desc.id,
+        "spec": {
+            "cron_expressions": list(sched.spec.cron_expressions),
+        },
+        "action": action_info,
+        "state": {
+            "paused": sched.state.paused,
+            "note": sched.state.note,
+            "limited_actions": sched.state.limited_actions,
+            "remaining_actions": sched.state.remaining_actions,
+        },
+        "info": {
+            "num_actions": info.num_actions,
+            "num_actions_missed_catchup_window": info.num_actions_missed_catchup_window,
+            "num_actions_skipped_overlap": info.num_actions_skipped_overlap,
+            "recent_actions": recent_actions,
+            "next_action_times": next_action_times,
+            "created_at": info.created_at.isoformat(),
+            "last_updated_at": info.last_updated_at.isoformat() if info.last_updated_at else None,
+        },
+    }
+
+    return [TextContent(type="text", text=json.dumps(result, indent=2))]

--- a/temporal_mcp/server.py
+++ b/temporal_mcp/server.py
@@ -140,6 +140,8 @@ class TemporalMCPServer:
                     return await schedule_handlers.delete_schedule(client, arguments)
                 elif name == "trigger_schedule":
                     return await schedule_handlers.trigger_schedule(client, arguments)
+                elif name == "describe_schedule":
+                    return await schedule_handlers.describe_schedule(client, arguments)
 
                 else:
                     return [TextContent(type="text", text=json.dumps({"error": f"Unknown tool: {name}", "type": "unknown_tool"}, indent=2))]

--- a/temporal_mcp/tools/tool_definitions.py
+++ b/temporal_mcp/tools/tool_definitions.py
@@ -325,6 +325,11 @@ def get_all_tools() -> list[Tool]:
             inputSchema={"type": "object", "properties": {"schedule_id": {"type": "string", "description": "The schedule ID to trigger"}}, "required": ["schedule_id"]},
         ),
         Tool(
+            name="describe_schedule",
+            description="Get detailed configuration and runtime information about a schedule, including its spec, action, state, recent executions, and upcoming action times",
+            inputSchema={"type": "object", "properties": {"schedule_id": {"type": "string", "description": "The schedule ID to describe"}}, "required": ["schedule_id"]},
+        ),
+        Tool(
             name="continue_as_new",
             description="Signal a workflow to continue as new (restart with new inputs while preserving history link)",
             inputSchema={

--- a/tests/test_schedule_handlers.py
+++ b/tests/test_schedule_handlers.py
@@ -2,6 +2,7 @@
 
 import json
 import pytest
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 from temporal_mcp.handlers import schedule_handlers
@@ -100,3 +101,125 @@ class TestScheduleHandlers:
         response = json.loads(result[0].text)
         assert response["status"] == "triggered"
         mock_handle.trigger.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_describe_schedule_success(self, mock_client):
+        from temporalio.client import ScheduleActionStartWorkflow
+
+        now = datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        next_time = datetime(2024, 1, 16, 9, 0, 0, tzinfo=timezone.utc)
+
+        mock_action = MagicMock(spec=ScheduleActionStartWorkflow)
+        mock_action.workflow = "TestWorkflow"
+        mock_action.task_queue = "test-queue"
+        mock_action.id = "test-schedule-workflow"
+
+        mock_spec = MagicMock()
+        mock_spec.cron_expressions = ["0 9 * * *"]
+
+        mock_state = MagicMock()
+        mock_state.paused = False
+        mock_state.note = None
+        mock_state.limited_actions = False
+        mock_state.remaining_actions = 0
+
+        mock_schedule = MagicMock()
+        mock_schedule.action = mock_action
+        mock_schedule.spec = mock_spec
+        mock_schedule.state = mock_state
+
+        mock_recent_action = MagicMock()
+        mock_recent_action.scheduled_at = now
+        mock_recent_action.started_at = now
+
+        mock_info = MagicMock()
+        mock_info.num_actions = 5
+        mock_info.num_actions_missed_catchup_window = 0
+        mock_info.num_actions_skipped_overlap = 1
+        mock_info.recent_actions = [mock_recent_action]
+        mock_info.next_action_times = [next_time]
+        mock_info.created_at = now
+        mock_info.last_updated_at = None
+
+        mock_description = MagicMock()
+        mock_description.id = "test-schedule"
+        mock_description.schedule = mock_schedule
+        mock_description.info = mock_info
+
+        mock_handle = AsyncMock()
+        mock_handle.describe = AsyncMock(return_value=mock_description)
+        mock_client.get_schedule_handle = MagicMock(return_value=mock_handle)
+
+        result = await schedule_handlers.describe_schedule(mock_client, {"schedule_id": "test-schedule"})
+
+        assert len(result) == 1
+        response = json.loads(result[0].text)
+
+        assert response["schedule_id"] == "test-schedule"
+        assert response["spec"]["cron_expressions"] == ["0 9 * * *"]
+        assert response["action"]["workflow"] == "TestWorkflow"
+        assert response["action"]["task_queue"] == "test-queue"
+        assert response["state"]["paused"] is False
+        assert response["state"]["note"] is None
+        assert response["info"]["num_actions"] == 5
+        assert response["info"]["num_actions_skipped_overlap"] == 1
+        assert len(response["info"]["recent_actions"]) == 1
+        assert response["info"]["recent_actions"][0]["scheduled_at"] == now.isoformat()
+        assert response["info"]["next_action_times"] == [next_time.isoformat()]
+        assert response["info"]["created_at"] == now.isoformat()
+        assert response["info"]["last_updated_at"] is None
+        mock_handle.describe.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_describe_schedule_with_last_updated_at(self, mock_client):
+        from temporalio.client import ScheduleActionStartWorkflow
+
+        now = datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        updated = datetime(2024, 1, 20, 12, 0, 0, tzinfo=timezone.utc)
+
+        mock_action = MagicMock(spec=ScheduleActionStartWorkflow)
+        mock_action.workflow = "TestWorkflow"
+        mock_action.task_queue = "test-queue"
+        mock_action.id = "test-schedule-workflow"
+
+        mock_spec = MagicMock()
+        mock_spec.cron_expressions = ["0 12 * * *"]
+
+        mock_state = MagicMock()
+        mock_state.paused = True
+        mock_state.note = "Paused for maintenance"
+        mock_state.limited_actions = False
+        mock_state.remaining_actions = 0
+
+        mock_schedule = MagicMock()
+        mock_schedule.action = mock_action
+        mock_schedule.spec = mock_spec
+        mock_schedule.state = mock_state
+
+        mock_info = MagicMock()
+        mock_info.num_actions = 10
+        mock_info.num_actions_missed_catchup_window = 2
+        mock_info.num_actions_skipped_overlap = 0
+        mock_info.recent_actions = []
+        mock_info.next_action_times = []
+        mock_info.created_at = now
+        mock_info.last_updated_at = updated
+
+        mock_description = MagicMock()
+        mock_description.id = "test-schedule"
+        mock_description.schedule = mock_schedule
+        mock_description.info = mock_info
+
+        mock_handle = AsyncMock()
+        mock_handle.describe = AsyncMock(return_value=mock_description)
+        mock_client.get_schedule_handle = MagicMock(return_value=mock_handle)
+
+        result = await schedule_handlers.describe_schedule(mock_client, {"schedule_id": "test-schedule"})
+
+        assert len(result) == 1
+        response = json.loads(result[0].text)
+
+        assert response["state"]["paused"] is True
+        assert response["state"]["note"] == "Paused for maintenance"
+        assert response["info"]["num_actions_missed_catchup_window"] == 2
+        assert response["info"]["last_updated_at"] == updated.isoformat()


### PR DESCRIPTION
## Summary

- Adds a new `describe_schedule` MCP tool with response: cron spec, workflow action (name, task queue, execution ID), pause state (paused flag, note, limited actions, remaining actions), and runtime info (action counts, recent executions with timestamps, next scheduled times, created/updated timestamps)

## Changes

| File | What changed |
|------|-------------|
| `temporal_mcp/handlers/schedule_handlers.py` | New `describe_schedule` handler; added `ScheduleDescription` import |
| `temporal_mcp/tools/tool_definitions.py` | New `describe_schedule` tool definition |
| `temporal_mcp/server.py` | Route `describe_schedule` to the new handler |
| `tests/test_schedule_handlers.py` | Two new tests covering happy path and `last_updated_at` present case |

## Test plan

- [x] `pytest tests/test_schedule_handlers.py -v` — all 8 tests pass (6 existing + 2 new)
- [x] `pytest tests/ -v` — all 81 tests pass
- [x] `flake8 temporal_mcp/` — no issues
- [x] `mypy temporal_mcp/` — no issues
- [x] `black --check temporal_mcp/` — no formatting changes needed