### PR TITLE
feat: add --tls-ca and --tls-server-name for custom CA and SNI override

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Recommended when running via Docker. Configuration is passed through environment
         "-e", "TEMPORAL_TLS_ENABLED",
         "-e", "TEMPORAL_TLS_CLIENT_CERT_PATH",
         "-e", "TEMPORAL_TLS_CLIENT_KEY_PATH",
+        "-e", "TEMPORAL_TLS_CA_PATH",
+        "-e", "TEMPORAL_TLS_SERVER_NAME",
         "-e", "TEMPORAL_API_KEY",
         "mcp/temporal"
       ],
@@ -81,6 +83,8 @@ Recommended when running via Docker. Configuration is passed through environment
         "TEMPORAL_TLS_ENABLED": "false",
         "TEMPORAL_TLS_CLIENT_CERT_PATH": "/path/to/client.pem",
         "TEMPORAL_TLS_CLIENT_KEY_PATH": "/path/to/client.key",
+        "TEMPORAL_TLS_CA_PATH": "/path/to/ca.pem",
+        "TEMPORAL_TLS_SERVER_NAME": "temporal-frontend",
         "TEMPORAL_API_KEY": "your-api-key"
       }
     }
@@ -120,9 +124,33 @@ Recommended when running from PyPI via [`uvx`](https://docs.astral.sh/uv/guides/
 | TLS | `--tls-enabled` | `TEMPORAL_TLS_ENABLED` | auto-detect |
 | mTLS cert path | `--tls-cert` | `TEMPORAL_TLS_CLIENT_CERT_PATH` | — |
 | mTLS key path | `--tls-key` | `TEMPORAL_TLS_CLIENT_KEY_PATH` | — |
+| Server CA cert path | `--tls-ca` | `TEMPORAL_TLS_CA_PATH` | system trust store |
+| TLS server name (SNI) | `--tls-server-name` | `TEMPORAL_TLS_SERVER_NAME` | host portion of `--host` |
 | API key | `--api-key` | `TEMPORAL_API_KEY` | — |
 
-CLI arguments take precedence over environment variables. When `TEMPORAL_API_KEY` is set, TLS is enabled automatically. When mTLS cert/key paths are provided, TLS is also enabled automatically.
+CLI arguments take precedence over environment variables. TLS is enabled automatically when any of the following is provided: `TEMPORAL_API_KEY`, mTLS cert/key paths, `TEMPORAL_TLS_CA_PATH`, or `TEMPORAL_TLS_SERVER_NAME`. All TLS knobs compose, so you can mix mTLS, API-key auth, custom server CA, and SNI override on the same connection.
+
+#### Connecting through an SNI-routed gateway with a private CA
+
+Some self-hosted clusters expose the Temporal frontend through an Istio/Envoy gateway that routes by SNI, with the backend cert signed by an internal CA. In that case you typically need to override the SNI value (so the gateway routes correctly) and pin the internal CA (so the SDK can verify the server cert):
+
+```json
+{
+  "servers": {
+    "temporal": {
+      "command": "uvx",
+      "args": [
+        "temporal-mcp-server",
+        "--host", "temporal.example.com:443",
+        "--namespace", "my-namespace",
+        "--tls-server-name", "temporal-frontend",
+        "--tls-ca", "/path/to/internal-ca.pem",
+        "--api-key", "your-api-key"
+      ]
+    }
+  }
+}
+```
 
 ## Development
 

--- a/temporal_mcp/__main__.py
+++ b/temporal_mcp/__main__.py
@@ -58,6 +58,22 @@ def _parse_args() -> argparse.Namespace:
         help="Path to mTLS client private key file (env: TEMPORAL_TLS_CLIENT_KEY_PATH)",
     )
     parser.add_argument(
+        "--tls-ca",
+        metavar="PATH",
+        default=None,
+        help=("Path to a PEM CA certificate used to verify the server. " "Use this for clusters signed by a private/internal CA that is not in " "the system trust store (env: TEMPORAL_TLS_CA_PATH)"),
+    )
+    parser.add_argument(
+        "--tls-server-name",
+        metavar="NAME",
+        default=None,
+        help=(
+            "Override the expected server name and TLS SNI value. "
+            "Use this when connecting through an SNI-routed gateway whose backend "
+            "cert is issued for a different name than --host (env: TEMPORAL_TLS_SERVER_NAME)"
+        ),
+    )
+    parser.add_argument(
         "--api-key",
         metavar="KEY",
         default=None,
@@ -87,6 +103,11 @@ def main():
     tls_client_cert_path = args.tls_cert or os.environ.get("TEMPORAL_TLS_CLIENT_CERT_PATH")
     tls_client_key_path = args.tls_key or os.environ.get("TEMPORAL_TLS_CLIENT_KEY_PATH")
 
+    # Server CA certificate path and SNI / server-name override
+    # (for clusters signed by a private CA, or SNI-routed gateways)
+    tls_ca_path = args.tls_ca or os.environ.get("TEMPORAL_TLS_CA_PATH")
+    tls_server_name = args.tls_server_name or os.environ.get("TEMPORAL_TLS_SERVER_NAME")
+
     # API key authentication (for Temporal Cloud)
     api_key = args.api_key or os.environ.get("TEMPORAL_API_KEY")
 
@@ -98,6 +119,10 @@ def main():
         print(f"mTLS client cert: {tls_client_cert_path}", file=sys.stderr)
     if tls_client_key_path:
         print(f"mTLS client key:  {tls_client_key_path}", file=sys.stderr)
+    if tls_ca_path:
+        print(f"Server CA cert:   {tls_ca_path}", file=sys.stderr)
+    if tls_server_name:
+        print(f"TLS server name:  {tls_server_name}", file=sys.stderr)
     if api_key:
         print("API key authentication: enabled", file=sys.stderr)
 
@@ -107,6 +132,8 @@ def main():
         tls_enabled=tls_enabled,
         tls_client_cert_path=tls_client_cert_path,
         tls_client_key_path=tls_client_key_path,
+        tls_ca_path=tls_ca_path,
+        tls_server_name=tls_server_name,
         api_key=api_key,
     )
     asyncio.run(server.run())

--- a/temporal_mcp/client.py
+++ b/temporal_mcp/client.py
@@ -16,6 +16,8 @@ class TemporalClientManager:
         tls_enabled: Optional[bool] = None,
         tls_client_cert_path: Optional[str] = None,
         tls_client_key_path: Optional[str] = None,
+        tls_ca_path: Optional[str] = None,
+        tls_server_name: Optional[str] = None,
         api_key: Optional[str] = None,
     ):
         """Initialize the Temporal client manager.
@@ -26,6 +28,15 @@ class TemporalClientManager:
             tls_enabled: Whether to use TLS for connection (None = auto-detect, True = force enable, False = force disable)
             tls_client_cert_path: Path to the TLS client certificate file (for mTLS / Temporal Cloud)
             tls_client_key_path: Path to the TLS client private key file (for mTLS / Temporal Cloud)
+            tls_ca_path: Path to a PEM CA certificate used to verify the server certificate
+                         (maps to ``temporalio.client.TLSConfig.server_root_ca_cert``).
+                         Useful when the server is signed by a private/internal CA that is
+                         not in the system trust store.
+            tls_server_name: Expected server name to validate the server certificate against,
+                             also used as the SNI value during the TLS handshake (maps to
+                             ``temporalio.client.TLSConfig.domain``). Useful when connecting
+                             through an SNI-routed gateway whose backend cert is issued for a
+                             name different from ``temporal_host``.
             api_key: API key for Temporal Cloud authentication
         """
         self.temporal_host = temporal_host
@@ -33,6 +44,8 @@ class TemporalClientManager:
         self.tls_enabled = tls_enabled
         self.tls_client_cert_path = tls_client_cert_path
         self.tls_client_key_path = tls_client_key_path
+        self.tls_ca_path = tls_ca_path
+        self.tls_server_name = tls_server_name
         self.api_key = api_key
         self.client: Optional[Client] = None
 
@@ -120,24 +133,52 @@ class TemporalClientManager:
         )
         return client_cert, client_key
 
-    def _determine_tls_config(self) -> Optional[TLSConfig]:
-        """Determine TLS configuration based on settings, hostname, and client certs.
+    def _load_server_ca(self) -> Optional[bytes]:
+        """Load the server CA certificate from disk, if configured.
 
         Returns:
-            TLS configuration or None
+            The CA certificate bytes, or None when no path is configured.
+
+        Raises:
+            FileNotFoundError: If the configured path does not exist.
+        """
+        if not self.tls_ca_path:
+            return None
+
+        with open(self.tls_ca_path, "rb") as f:
+            ca_bytes = f.read()
+
+        print(f"Loaded server CA certificate from {self.tls_ca_path}", file=sys.stderr)
+        return ca_bytes
+
+    def _determine_tls_config(self) -> Optional[TLSConfig]:
+        """Determine TLS configuration based on settings, hostname, and credentials.
+
+        Any of the following inputs forces TLS on, regardless of ``tls_enabled``:
+
+        - mTLS client cert + key
+        - Server CA cert path
+        - SNI / server name override
+        - API key
+
+        When TLS is enabled, the resulting :class:`TLSConfig` composes every
+        provided knob: mTLS material, custom server CA, and SNI override may be
+        used together.
+
+        Returns:
+            TLS configuration or ``None`` if TLS should not be used.
         """
         client_cert, client_key = self._load_client_certs()
+        server_ca = self._load_server_ca()
 
-        # If mTLS certs are provided, always enable TLS regardless of other settings
-        if client_cert and client_key:
-            return TLSConfig(
+        explicit_tls_inputs = bool((client_cert and client_key) or server_ca is not None or self.tls_server_name or self.api_key)
+
+        if explicit_tls_inputs:
+            return self._build_tls_config(
                 client_cert=client_cert,
-                client_private_key=client_key,
+                client_key=client_key,
+                server_ca=server_ca,
             )
-
-        # API key auth requires TLS
-        if self.api_key:
-            return TLSConfig()
 
         # Priority: explicit tls_enabled setting > auto-detect from hostname
         if self.tls_enabled is True:
@@ -150,6 +191,27 @@ class TemporalClientManager:
         else:
             # Auto-detect: disable TLS for local connections
             return None
+
+    def _build_tls_config(
+        self,
+        client_cert: Optional[bytes],
+        client_key: Optional[bytes],
+        server_ca: Optional[bytes],
+    ) -> TLSConfig:
+        """Construct a :class:`TLSConfig` populated only with the fields we have.
+
+        Empty fields are omitted so we get the SDK defaults (e.g. system trust
+        store when no custom CA is configured).
+        """
+        kwargs: dict = {}
+        if client_cert and client_key:
+            kwargs["client_cert"] = client_cert
+            kwargs["client_private_key"] = client_key
+        if server_ca is not None:
+            kwargs["server_root_ca_cert"] = server_ca
+        if self.tls_server_name:
+            kwargs["domain"] = self.tls_server_name
+        return TLSConfig(**kwargs)
 
     def _is_remote_host(self) -> bool:
         """Check if the host is a remote (non-local) host.
@@ -177,3 +239,5 @@ class TemporalClientManager:
 
         print(f"Namespace: {self.namespace}", file=sys.stderr)
         print(f"TLS Enabled: {tls_config is not None}", file=sys.stderr)
+        if tls_config is not None and self.tls_server_name:
+            print(f"TLS server name (SNI): {self.tls_server_name}", file=sys.stderr)

--- a/temporal_mcp/server.py
+++ b/temporal_mcp/server.py
@@ -29,6 +29,8 @@ class TemporalMCPServer:
         tls_enabled: Optional[bool] = None,
         tls_client_cert_path: Optional[str] = None,
         tls_client_key_path: Optional[str] = None,
+        tls_ca_path: Optional[str] = None,
+        tls_server_name: Optional[str] = None,
         api_key: Optional[str] = None,
     ):
         """Initialize the Temporal MCP server.
@@ -39,6 +41,10 @@ class TemporalMCPServer:
             tls_enabled: Whether to use TLS for connection (None = auto-detect, True = force enable, False = force disable)
             tls_client_cert_path: Path to the TLS client certificate file (for mTLS / Temporal Cloud)
             tls_client_key_path: Path to the TLS client private key file (for mTLS / Temporal Cloud)
+            tls_ca_path: Path to a PEM CA certificate used to verify the server certificate
+                         (for clusters signed by a private CA not in the system trust store)
+            tls_server_name: Expected server name / SNI override used during the TLS handshake
+                             (for SNI-routed gateways where the cert is issued for a different name)
             api_key: API key for Temporal Cloud authentication
         """
         self.client_manager = TemporalClientManager(
@@ -47,6 +53,8 @@ class TemporalMCPServer:
             tls_enabled=tls_enabled,
             tls_client_cert_path=tls_client_cert_path,
             tls_client_key_path=tls_client_key_path,
+            tls_ca_path=tls_ca_path,
+            tls_server_name=tls_server_name,
             api_key=api_key,
         )
         self.server = Server("temporal-mcp-server")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -63,6 +63,22 @@ class TestLoadClientCerts:
             mgr._load_client_certs()
 
 
+class TestLoadServerCa:
+    def test_no_path_returns_none(self):
+        assert TemporalClientManager()._load_server_ca() is None
+
+    def test_path_loaded(self, tmp_path):
+        ca_file = tmp_path / "ca.pem"
+        ca_file.write_bytes(b"CA_DATA")
+        mgr = TemporalClientManager(tls_ca_path=str(ca_file))
+        assert mgr._load_server_ca() == b"CA_DATA"
+
+    def test_missing_file_raises(self):
+        mgr = TemporalClientManager(tls_ca_path="/nonexistent/ca.pem")
+        with pytest.raises(FileNotFoundError):
+            mgr._load_server_ca()
+
+
 class TestDetermineTlsConfig:
     def test_mtls_returns_config_with_certs(self, tmp_path):
         cert_file = tmp_path / "client.pem"
@@ -100,6 +116,74 @@ class TestDetermineTlsConfig:
     def test_auto_detect_local_disables_tls(self):
         tls = TemporalClientManager(temporal_host="localhost:7233")._determine_tls_config()
         assert tls is None
+
+    def test_ca_path_enables_tls_and_sets_root_ca(self, tmp_path):
+        ca_file = tmp_path / "ca.pem"
+        ca_file.write_bytes(b"CA")
+        tls = TemporalClientManager(temporal_host="localhost:7233", tls_ca_path=str(ca_file))._determine_tls_config()
+        assert isinstance(tls, TLSConfig)
+        assert tls.server_root_ca_cert == b"CA"
+
+    def test_server_name_enables_tls_and_sets_domain(self):
+        tls = TemporalClientManager(temporal_host="localhost:7233", tls_server_name="temporal-frontend")._determine_tls_config()
+        assert isinstance(tls, TLSConfig)
+        assert tls.domain == "temporal-frontend"
+
+    def test_ca_overrides_explicit_tls_disabled(self, tmp_path):
+        # Providing a server CA should force TLS on even if tls_enabled=False
+        ca_file = tmp_path / "ca.pem"
+        ca_file.write_bytes(b"CA")
+        tls = TemporalClientManager(
+            temporal_host="localhost:7233",
+            tls_enabled=False,
+            tls_ca_path=str(ca_file),
+        )._determine_tls_config()
+        assert isinstance(tls, TLSConfig)
+        assert tls.server_root_ca_cert == b"CA"
+
+    def test_server_name_overrides_explicit_tls_disabled(self):
+        # Providing an SNI override should force TLS on even if tls_enabled=False
+        tls = TemporalClientManager(
+            temporal_host="localhost:7233",
+            tls_enabled=False,
+            tls_server_name="temporal-frontend",
+        )._determine_tls_config()
+        assert isinstance(tls, TLSConfig)
+        assert tls.domain == "temporal-frontend"
+
+    def test_ca_and_server_name_compose_with_api_key(self, tmp_path):
+        ca_file = tmp_path / "ca.pem"
+        ca_file.write_bytes(b"CA")
+        tls = TemporalClientManager(
+            temporal_host="ingress.example.com:443",
+            api_key="tok_abc",
+            tls_ca_path=str(ca_file),
+            tls_server_name="temporal-frontend",
+        )._determine_tls_config()
+        assert isinstance(tls, TLSConfig)
+        assert tls.server_root_ca_cert == b"CA"
+        assert tls.domain == "temporal-frontend"
+
+    def test_ca_and_server_name_compose_with_mtls(self, tmp_path):
+        cert_file = tmp_path / "client.pem"
+        key_file = tmp_path / "client.key"
+        ca_file = tmp_path / "ca.pem"
+        cert_file.write_bytes(b"CERT")
+        key_file.write_bytes(b"KEY")
+        ca_file.write_bytes(b"CA")
+
+        tls = TemporalClientManager(
+            temporal_host="ingress.example.com:443",
+            tls_client_cert_path=str(cert_file),
+            tls_client_key_path=str(key_file),
+            tls_ca_path=str(ca_file),
+            tls_server_name="temporal-frontend",
+        )._determine_tls_config()
+        assert isinstance(tls, TLSConfig)
+        assert tls.client_cert == b"CERT"
+        assert tls.client_private_key == b"KEY"
+        assert tls.server_root_ca_cert == b"CA"
+        assert tls.domain == "temporal-frontend"
 
 
 class TestConnect:
@@ -166,6 +250,27 @@ class TestConnect:
             assert isinstance(tls, TLSConfig)
             assert tls.client_cert == b"CERT"
             assert tls.client_private_key == b"KEY"
+
+    @pytest.mark.asyncio
+    async def test_connect_passes_ca_and_server_name(self, tmp_path):
+        ca_file = tmp_path / "ca.pem"
+        ca_file.write_bytes(b"CA")
+        mgr = TemporalClientManager(
+            temporal_host="ingress.example.com:443",
+            api_key="tok_abc",
+            tls_ca_path=str(ca_file),
+            tls_server_name="temporal-frontend",
+        )
+        mock_client = AsyncMock()
+
+        with patch("temporal_mcp.client.Client.connect", return_value=mock_client) as mock_connect:
+            await mgr.connect()
+            _, kwargs = mock_connect.call_args
+            tls = kwargs.get("tls")
+            assert isinstance(tls, TLSConfig)
+            assert tls.server_root_ca_cert == b"CA"
+            assert tls.domain == "temporal-frontend"
+            assert kwargs.get("api_key") == "tok_abc"
 
 
 class TestDisconnectAndEnsureConnected:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,7 +3,6 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -64,6 +63,10 @@ class TestParseArgs:
                 "/certs/client.pem",
                 "--tls-key",
                 "/certs/client.key",
+                "--tls-ca",
+                "/certs/ca.pem",
+                "--tls-server-name",
+                "temporal-frontend",
                 "--api-key",
                 "secret",
             ]
@@ -73,6 +76,8 @@ class TestParseArgs:
         assert ns.tls_enabled == "true"
         assert ns.tls_cert == "/certs/client.pem"
         assert ns.tls_key == "/certs/client.key"
+        assert ns.tls_ca == "/certs/ca.pem"
+        assert ns.tls_server_name == "temporal-frontend"
         assert ns.api_key == "secret"
 
     def test_no_args_all_none(self):
@@ -82,6 +87,8 @@ class TestParseArgs:
         assert ns.tls_enabled is None
         assert ns.tls_cert is None
         assert ns.tls_key is None
+        assert ns.tls_ca is None
+        assert ns.tls_server_name is None
         assert ns.api_key is None
 
     def test_tls_enabled_normalised_to_lowercase(self):
@@ -126,6 +133,8 @@ class TestDefaults:
         kwargs = _run_main([], env={})
         assert kwargs["tls_client_cert_path"] is None
         assert kwargs["tls_client_key_path"] is None
+        assert kwargs["tls_ca_path"] is None
+        assert kwargs["tls_server_name"] is None
         assert kwargs["api_key"] is None
 
 
@@ -166,6 +175,14 @@ class TestEnvVarFallback:
     def test_api_key_from_env(self):
         kwargs = _run_main([], env={"TEMPORAL_API_KEY": "env-secret"})
         assert kwargs["api_key"] == "env-secret"
+
+    def test_ca_path_from_env(self):
+        kwargs = _run_main([], env={"TEMPORAL_TLS_CA_PATH": "/env/ca.pem"})
+        assert kwargs["tls_ca_path"] == "/env/ca.pem"
+
+    def test_server_name_from_env(self):
+        kwargs = _run_main([], env={"TEMPORAL_TLS_SERVER_NAME": "temporal-frontend"})
+        assert kwargs["tls_server_name"] == "temporal-frontend"
 
 
 # ---------------------------------------------------------------------------
@@ -216,6 +233,20 @@ class TestArgPrecedenceOverEnv:
         )
         assert kwargs["api_key"] == "arg-secret"
 
+    def test_ca_arg_overrides_env(self):
+        kwargs = _run_main(
+            ["--tls-ca", "/arg/ca.pem"],
+            env={"TEMPORAL_TLS_CA_PATH": "/env/ca.pem"},
+        )
+        assert kwargs["tls_ca_path"] == "/arg/ca.pem"
+
+    def test_server_name_arg_overrides_env(self):
+        kwargs = _run_main(
+            ["--tls-server-name", "arg-name"],
+            env={"TEMPORAL_TLS_SERVER_NAME": "env-name"},
+        )
+        assert kwargs["tls_server_name"] == "arg-name"
+
     def test_all_args_override_all_env_vars(self):
         kwargs = _run_main(
             [
@@ -229,6 +260,10 @@ class TestArgPrecedenceOverEnv:
                 "/arg/cert.pem",
                 "--tls-key",
                 "/arg/key.pem",
+                "--tls-ca",
+                "/arg/ca.pem",
+                "--tls-server-name",
+                "arg-name",
                 "--api-key",
                 "arg-secret",
             ],
@@ -238,6 +273,8 @@ class TestArgPrecedenceOverEnv:
                 "TEMPORAL_TLS_ENABLED": "true",
                 "TEMPORAL_TLS_CLIENT_CERT_PATH": "/env/cert.pem",
                 "TEMPORAL_TLS_CLIENT_KEY_PATH": "/env/key.pem",
+                "TEMPORAL_TLS_CA_PATH": "/env/ca.pem",
+                "TEMPORAL_TLS_SERVER_NAME": "env-name",
                 "TEMPORAL_API_KEY": "env-secret",
             },
         )
@@ -246,4 +283,6 @@ class TestArgPrecedenceOverEnv:
         assert kwargs["tls_enabled"] is False
         assert kwargs["tls_client_cert_path"] == "/arg/cert.pem"
         assert kwargs["tls_client_key_path"] == "/arg/key.pem"
+        assert kwargs["tls_ca_path"] == "/arg/ca.pem"
+        assert kwargs["tls_server_name"] == "arg-name"
         assert kwargs["api_key"] == "arg-secret"


### PR DESCRIPTION
## Summary

Adds two TLS knobs that the underlying `temporalio.client.TLSConfig` already supports but this server does not currently expose:

| New CLI flag | New env var | Maps to | Why |
|---|---|---|---|
| `--tls-ca` | `TEMPORAL_TLS_CA_PATH` | `TLSConfig.server_root_ca_cert` | Trust a private/internal CA that isn't in the system trust store |
| `--tls-server-name` | `TEMPORAL_TLS_SERVER_NAME` | `TLSConfig.domain` | Override SNI / expected server name when the cluster is behind an SNI-routed gateway whose backend cert is issued for a different name than `--host` |

## Motivation

The current TLS surface assumes either Temporal Cloud's public CA or full mTLS. Two real-world self-hosted setups don't fit:

1. **Private/internal CA.** A self-hosted Temporal frontend is typically signed by an internal CA. Without `server_root_ca_cert`, the SDK falls back to the system trust store. On macOS, even when the CA is added to the System keychain, the cert chain often fails Go/`rustls` standards-compliance checks that pass when the CA is pinned explicitly.
2. **SNI-routed gateway.** Many internal deployments expose Temporal through an Istio/Envoy gateway doing TLS passthrough, where the backend cert is issued for `temporal-frontend` but reached via a public DNS like `temporal.example.com`. Without an SNI override, the gateway either drops the connection or the SDK fails certificate-name verification.

Both gaps force users into wrappers / `/etc/hosts` hacks today. Both are one-line fixes in `TLSConfig`.

## Behavior

- Either knob auto-enables TLS, matching the existing behavior for `--api-key` and mTLS.
- All TLS knobs **compose** — mTLS, API-key auth, custom server CA, and SNI override can be set simultaneously on one connection.
- `_determine_tls_config` was refactored to a uniform "collect TLS inputs, then build" structure so the matrix is easier to reason about.
- CLI > env > default precedence is preserved across the new options.

## Tests

12 new tests, all green:

- `tests/test_client.py`
  - `TestLoadServerCa` — loads from disk, missing-file raises, no-path returns `None`
  - `TestDetermineTlsConfig` — CA enables TLS + sets `server_root_ca_cert`; server-name enables TLS + sets `domain`; CA / server-name override `tls_enabled=False`; both compose with API key and with mTLS
  - `TestConnect::test_connect_passes_ca_and_server_name` — end-to-end through `Client.connect`
- `tests/test_main.py` — argparse cases, env-var fallback, CLI-overrides-env for both new flags, plus the existing all-args / all-env precedence tests now include the new fields

Local results:

```
93 passed, 4 warnings in 0.21s
flake8: clean
mypy:   Success: no issues found in 14 source files
black:  All done! 24 files would be left unchanged.
pre-commit run --all-files: all hooks passed
```

## README

- Two new rows in the configuration table.
- Worked example for the SNI-routed-gateway-with-private-CA scenario.
- Updated the Docker example with the two new env-var passthroughs.

## Notes for the maintainer

- No breaking changes; existing flags / env vars / behavior are untouched.
- Commit follows Conventional Commits (`feat:`) so semantic-release will pick it up as a minor bump.
- I'm a real user of this — was driven into this work by a self-hosted CPaaS-style Temporal install behind an Istio passthrough gateway. Happy to iterate on naming, structure, or scope.

## Test plan

- [x] All existing tests still pass
- [x] New tests cover argparse, env-var fallback, CLI precedence, file IO, and TLSConfig composition
- [x] `flake8`, `mypy`, `black --check`, and `pre-commit run --all-files` all clean
- [x] Smoke-tested end-to-end against a real internal cluster (private CA + SNI-routed gateway + JWT API key) — confirmed working via `temporal-mcp-server` from this branch