### PR TITLE
Add workflow event payload tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Read more on the [Temporal Code Exchange](https://temporal.io/code-exchange/temp
 - **`describe_workflow`** - Get detailed information about a workflow execution including status, timing, and metadata
 - **`list_workflows`** - List workflow executions based on a query filter with pagination support (limit/skip)
 - **`get_workflow_history`** - Retrieve the complete event history of a workflow execution
+- **`get_workflow_event`** - Retrieve a single workflow history event with decoded payload fields when present
 
 ### Workflow Control
 

--- a/temporal_mcp/handlers/workflow_handlers.py
+++ b/temporal_mcp/handlers/workflow_handlers.py
@@ -3,10 +3,13 @@
 import asyncio
 import json
 import sys
+from typing import Any
 
 from mcp.types import TextContent
 from temporalio.client import Client
-from temporalio.api.enums.v1 import WorkflowExecutionStatus
+from temporalio.api.common.v1 import Payloads
+from temporalio.api.enums.v1 import EventType, RetryState, WorkflowExecutionStatus
+from temporalio.api.failure.v1 import Failure
 
 
 async def start_workflow(client: Client, args: dict) -> list[TextContent]:
@@ -237,3 +240,152 @@ async def get_workflow_history(client: Client, args: dict) -> list[TextContent]:
             break
 
     return [TextContent(type="text", text=json.dumps({"workflow_id": workflow_id, "events": events, "count": len(events)}, indent=2))]
+
+
+async def get_workflow_event(client: Client, args: dict) -> list[TextContent]:
+    """Get a single workflow history event with decoded payload fields.
+
+    Args:
+        client: Connected Temporal client
+        args: Arguments containing workflow_id, event_id, and optional run_id
+
+    Returns:
+        Workflow history event with decoded payload fields when present
+    """
+    workflow_id = args["workflow_id"]
+    event_id = int(args["event_id"])
+    run_id = args.get("run_id")
+
+    handle = client.get_workflow_handle(workflow_id, run_id=run_id)
+
+    scheduled_activities: dict[int, dict[str, Any]] = {}
+    async for event in handle.fetch_history_events():
+        if event.WhichOneof("attributes") == "activity_task_scheduled_event_attributes":
+            attrs = event.activity_task_scheduled_event_attributes
+            scheduled_activities[event.event_id] = {
+                "activity_id": attrs.activity_id,
+                "activity_type": attrs.activity_type.name,
+            }
+
+        if event.event_id == event_id:
+            result = {
+                "workflow_id": workflow_id,
+                "run_id": run_id,
+                "event": await _workflow_event_to_dict(client, event, scheduled_activities),
+            }
+            return [TextContent(type="text", text=json.dumps(result, indent=2, default=str))]
+
+    return [
+        TextContent(
+            type="text",
+            text=json.dumps(
+                {
+                    "error": f"Event {event_id} not found in workflow history",
+                    "type": "not_found",
+                    "workflow_id": workflow_id,
+                    "run_id": run_id,
+                    "event_id": event_id,
+                },
+                indent=2,
+            ),
+        )
+    ]
+
+
+async def _workflow_event_to_dict(client: Client, event: Any, scheduled_activities: dict[int, dict[str, Any]]) -> dict[str, Any]:
+    event_info = {
+        "event_id": event.event_id,
+        "event_type": event.event_type,
+        "event_type_name": _enum_name(EventType, event.event_type),
+        "event_time": str(event.event_time),
+        "attributes": {},
+    }
+
+    attributes_type = event.WhichOneof("attributes")
+    if attributes_type == "workflow_execution_started_event_attributes":
+        attrs = event.workflow_execution_started_event_attributes
+        event_info["attributes"] = {
+            "workflow_type": attrs.workflow_type.name,
+            "input": await _decode_payloads(client, attrs.input, collapse_single=False),
+        }
+    elif attributes_type == "activity_task_scheduled_event_attributes":
+        attrs = event.activity_task_scheduled_event_attributes
+        event_info["attributes"] = {
+            "activity": {
+                "activity_id": attrs.activity_id,
+                "activity_type": attrs.activity_type.name,
+            },
+            "input": await _decode_payloads(client, attrs.input, collapse_single=False),
+        }
+    elif attributes_type == "activity_task_completed_event_attributes":
+        attrs = event.activity_task_completed_event_attributes
+        event_info["attributes"] = {
+            "scheduled_event_id": attrs.scheduled_event_id,
+            "started_event_id": attrs.started_event_id,
+            "activity": scheduled_activities.get(attrs.scheduled_event_id),
+            "result": await _decode_payloads(client, attrs.result, collapse_single=True),
+        }
+    elif attributes_type == "activity_task_failed_event_attributes":
+        attrs = event.activity_task_failed_event_attributes
+        event_info["attributes"] = {
+            "scheduled_event_id": attrs.scheduled_event_id,
+            "started_event_id": attrs.started_event_id,
+            "activity": scheduled_activities.get(attrs.scheduled_event_id),
+            "retry_state": attrs.retry_state,
+            "retry_state_name": _enum_name(RetryState, attrs.retry_state),
+            "failure": await _decode_failure(client, attrs.failure),
+        }
+    elif attributes_type == "workflow_execution_failed_event_attributes":
+        attrs = event.workflow_execution_failed_event_attributes
+        event_info["attributes"] = {
+            "retry_state": attrs.retry_state,
+            "retry_state_name": _enum_name(RetryState, attrs.retry_state),
+            "failure": await _decode_failure(client, attrs.failure),
+        }
+
+    return event_info
+
+
+async def _decode_payloads(client: Client, payloads: Payloads, *, collapse_single: bool) -> dict[str, Any]:
+    payload_list = list(payloads.payloads)
+    try:
+        values = await client.data_converter.decode(payload_list)
+        return {
+            "decoded": True,
+            "value": values[0] if collapse_single and len(values) == 1 else values,
+            "payload_count": len(payload_list),
+        }
+    except Exception as e:
+        return {
+            "decoded": False,
+            "error": str(e),
+            "error_type": type(e).__name__,
+            "payload_count": len(payload_list),
+        }
+
+
+async def _decode_failure(client: Client, failure: Failure) -> dict[str, Any]:
+    try:
+        decoded_failure = await client.data_converter.decode_failure(failure)
+        return {
+            "decoded": True,
+            "message": getattr(decoded_failure, "message", str(decoded_failure)),
+            "type": type(decoded_failure).__name__,
+            "details": list(getattr(decoded_failure, "details", [])),
+        }
+    except Exception as e:
+        return {
+            "decoded": False,
+            "message": failure.message,
+            "source": failure.source,
+            "stack_trace": failure.stack_trace,
+            "error": str(e),
+            "error_type": type(e).__name__,
+        }
+
+
+def _enum_name(enum_type: Any, value: Any) -> str:
+    try:
+        return str(enum_type.Name(int(value)))
+    except Exception:
+        return str(value)

--- a/temporal_mcp/server.py
+++ b/temporal_mcp/server.py
@@ -88,6 +88,8 @@ class TemporalMCPServer:
                     return await workflow_handlers.list_workflows(client, arguments)
                 elif name == "get_workflow_history":
                     return await workflow_handlers.get_workflow_history(client, arguments)
+                elif name == "get_workflow_event":
+                    return await workflow_handlers.get_workflow_event(client, arguments)
 
                 # Standalone activity operations
                 elif name == "start_activity":

--- a/temporal_mcp/tools/tool_definitions.py
+++ b/temporal_mcp/tools/tool_definitions.py
@@ -99,6 +99,19 @@ def get_all_tools() -> list[Tool]:
             },
         ),
         Tool(
+            name="get_workflow_event",
+            description="Get a single workflow history event with decoded payload fields when present",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "workflow_id": {"type": "string", "description": "The workflow execution ID"},
+                    "event_id": {"type": "number", "description": "The history event ID to fetch"},
+                    "run_id": {"type": "string", "description": "Optional run ID for the workflow execution"},
+                },
+                "required": ["workflow_id", "event_id"],
+            },
+        ),
+        Tool(
             name="start_activity",
             description="Start a new standalone Temporal activity execution",
             inputSchema={

--- a/tests/test_workflow_handlers.py
+++ b/tests/test_workflow_handlers.py
@@ -3,7 +3,12 @@
 import json
 import pytest
 from unittest.mock import AsyncMock, MagicMock
-from datetime import datetime
+from datetime import datetime, timezone
+from google.protobuf.timestamp_pb2 import Timestamp
+from temporalio.api.common.v1 import ActivityType, Payloads, WorkflowType
+from temporalio.api.enums.v1 import EventType
+from temporalio.api.history.v1 import ActivityTaskCompletedEventAttributes, ActivityTaskScheduledEventAttributes, HistoryEvent, WorkflowExecutionStartedEventAttributes
+from temporalio.converter import default
 
 from temporal_mcp.handlers import workflow_handlers
 
@@ -163,3 +168,112 @@ class TestGetWorkflowHistory:
         assert response["workflow_id"] == "test-workflow-123"
         assert len(response["events"]) == 2
         assert response["events"][0]["event_type"] == "WorkflowExecutionStarted"
+
+
+class TestGetWorkflowEvent:
+    @pytest.mark.asyncio
+    async def test_get_workflow_event_decodes_activity_result(self, mock_client):
+        data_converter = default()
+
+        scheduled_event = _history_event(
+            event_id=8,
+            event_type=EventType.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED,
+            activity_task_scheduled_event_attributes=ActivityTaskScheduledEventAttributes(
+                activity_id="activity-123",
+                activity_type=ActivityType(name="FetchCustomer"),
+                input=Payloads(payloads=await data_converter.encode([{"customer_id": "123"}])),
+            ),
+        )
+        completed_event = _history_event(
+            event_id=12,
+            event_type=EventType.EVENT_TYPE_ACTIVITY_TASK_COMPLETED,
+            activity_task_completed_event_attributes=ActivityTaskCompletedEventAttributes(
+                scheduled_event_id=8,
+                started_event_id=10,
+                result=Payloads(payloads=await data_converter.encode([{"status": "active"}])),
+            ),
+        )
+
+        async def mock_fetch_history_events():
+            for event in [scheduled_event, completed_event]:
+                yield event
+
+        mock_handle = AsyncMock()
+        mock_handle.fetch_history_events = mock_fetch_history_events
+        mock_client.get_workflow_handle = MagicMock(return_value=mock_handle)
+        mock_client.data_converter = data_converter
+
+        result = await workflow_handlers.get_workflow_event(mock_client, {"workflow_id": "test-workflow-123", "event_id": 12})
+
+        response = json.loads(result[0].text)
+        event = response["event"]
+        attrs = event["attributes"]
+
+        assert response["workflow_id"] == "test-workflow-123"
+        assert event["event_id"] == 12
+        assert event["event_type_name"] == "EVENT_TYPE_ACTIVITY_TASK_COMPLETED"
+        assert attrs["scheduled_event_id"] == 8
+        assert attrs["started_event_id"] == 10
+        assert attrs["activity"] == {"activity_id": "activity-123", "activity_type": "FetchCustomer"}
+        assert attrs["result"] == {"decoded": True, "value": {"status": "active"}, "payload_count": 1}
+        mock_client.get_workflow_handle.assert_called_once_with("test-workflow-123", run_id=None)
+
+    @pytest.mark.asyncio
+    async def test_get_workflow_event_reports_payload_decode_failure(self, mock_client):
+        data_converter = _FailingDataConverter()
+
+        event = _history_event(
+            event_id=1,
+            event_type=EventType.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+            workflow_execution_started_event_attributes=WorkflowExecutionStartedEventAttributes(
+                workflow_type=WorkflowType(name="TestWorkflow"),
+                input=Payloads(payloads=await default().encode([{"customer_id": "123"}])),
+            ),
+        )
+
+        async def mock_fetch_history_events():
+            yield event
+
+        mock_handle = AsyncMock()
+        mock_handle.fetch_history_events = mock_fetch_history_events
+        mock_client.get_workflow_handle = MagicMock(return_value=mock_handle)
+        mock_client.data_converter = data_converter
+
+        result = await workflow_handlers.get_workflow_event(mock_client, {"workflow_id": "test-workflow-123", "event_id": 1, "run_id": "run-456"})
+
+        response = json.loads(result[0].text)
+        decoded_input = response["event"]["attributes"]["input"]
+
+        assert response["run_id"] == "run-456"
+        assert decoded_input["decoded"] is False
+        assert decoded_input["error"] == "bad payload"
+        assert decoded_input["error_type"] == "ValueError"
+        assert decoded_input["payload_count"] == 1
+        mock_client.get_workflow_handle.assert_called_once_with("test-workflow-123", run_id="run-456")
+
+    @pytest.mark.asyncio
+    async def test_get_workflow_event_not_found(self, mock_client):
+        async def mock_fetch_history_events():
+            if False:
+                yield None
+
+        mock_handle = AsyncMock()
+        mock_handle.fetch_history_events = mock_fetch_history_events
+        mock_client.get_workflow_handle = MagicMock(return_value=mock_handle)
+
+        result = await workflow_handlers.get_workflow_event(mock_client, {"workflow_id": "test-workflow-123", "event_id": 99})
+
+        response = json.loads(result[0].text)
+        assert response["type"] == "not_found"
+        assert response["event_id"] == 99
+
+
+def _history_event(event_id, event_type, **attributes):
+    event_time = Timestamp()
+    event_time.FromDatetime(datetime(2025, 10, 30, 12, 0, event_id % 60, tzinfo=timezone.utc))
+    return HistoryEvent(event_id=event_id, event_type=event_type, event_time=event_time, **attributes)
+
+
+class _FailingDataConverter:
+    async def decode(self, payloads):
+        raise ValueError("bad payload")


### PR DESCRIPTION
## Summary

Adds `get_workflow_event` for targeted inspection of one workflow history event. This keeps `get_workflow_history` lightweight while allowing callers to fetch decoded payloads only when needed.

Closes #36.

## What changed

- Added a new `get_workflow_event(workflow_id, event_id, run_id?)` tool.
- Decodes known payload fields for workflow start, activity scheduled, activity completed, activity failed, and workflow failed events.
- Reports decode failures per field instead of failing the whole tool.
- Correlates activity completed and failed events back to scheduled activity metadata.
- Documents the tool in the README.

## Examples

Activity completed result:

```json
{
  "workflow_id": "customer-workflow",
  "event": {
    "event_id": 12,
    "event_type_name": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
    "attributes": {
      "scheduled_event_id": 8,
      "started_event_id": 10,
      "activity": {
        "activity_id": "activity-123",
        "activity_type": "FetchCustomer"
      },
      "result": {
        "decoded": true,
        "value": {"status": "active"},
        "payload_count": 1
      }
    }
  }
}
```

Decode failure:

```json
{
  "input": {
    "decoded": false,
    "error": "Unable to decode payload with configured data converter",
    "error_type": "ValueError",
    "payload_count": 1
  }
}
```

## Tests

- `pytest -q`
- `black --check temporal_mcp/handlers/workflow_handlers.py temporal_mcp/tools/tool_definitions.py temporal_mcp/server.py tests/test_workflow_handlers.py`
- `flake8 temporal_mcp/handlers/workflow_handlers.py temporal_mcp/tools/tool_definitions.py temporal_mcp/server.py tests/test_workflow_handlers.py`
- `mypy temporal_mcp/handlers/workflow_handlers.py temporal_mcp/server.py`
- `git diff --check`
