### PR TITLE
Enrich workflow history metadata

### DIFF
--- a/temporal_mcp/handlers/workflow_handlers.py
+++ b/temporal_mcp/handlers/workflow_handlers.py
@@ -8,7 +8,7 @@ from typing import Any
 from mcp.types import TextContent
 from temporalio.client import Client
 from temporalio.api.common.v1 import Payloads
-from temporalio.api.enums.v1 import EventType, RetryState, WorkflowExecutionStatus
+from temporalio.api.enums.v1 import EventType, RetryState, StartChildWorkflowExecutionFailedCause, TimeoutType, WorkflowExecutionStatus
 from temporalio.api.failure.v1 import Failure
 
 
@@ -226,20 +226,171 @@ async def get_workflow_history(client: Client, args: dict) -> list[TextContent]:
     handle = client.get_workflow_handle(workflow_id)
 
     events = []
+    scheduled_activities: dict[int, dict[str, Any]] = {}
+    initiated_child_workflows: dict[int, dict[str, Any]] = {}
     count = 0
     async for event in handle.fetch_history_events():
-        events.append(
-            {
-                "event_id": event.event_id,
-                "event_type": event.event_type,
-                "event_time": str(event.event_time),
+        attributes_type = event.WhichOneof("attributes")
+        if attributes_type == "activity_task_scheduled_event_attributes":
+            scheduled_attrs = event.activity_task_scheduled_event_attributes
+            scheduled_activities[event.event_id] = {
+                "activity_id": scheduled_attrs.activity_id,
+                "activity_type": scheduled_attrs.activity_type.name,
             }
-        )
+        elif attributes_type == "start_child_workflow_execution_initiated_event_attributes":
+            initiated_attrs = event.start_child_workflow_execution_initiated_event_attributes
+            initiated_child_workflows[event.event_id] = {
+                "workflow_id": initiated_attrs.workflow_id,
+                "workflow_type": initiated_attrs.workflow_type.name,
+            }
+
+        events.append(_workflow_history_event_to_dict(event, scheduled_activities, initiated_child_workflows))
         count += 1
         if count >= limit:
             break
 
     return [TextContent(type="text", text=json.dumps({"workflow_id": workflow_id, "events": events, "count": len(events)}, indent=2))]
+
+
+def _workflow_history_event_to_dict(event: Any, scheduled_activities: dict[int, dict[str, Any]], initiated_child_workflows: dict[int, dict[str, Any]]) -> dict[str, Any]:
+    event_info = {
+        "event_id": event.event_id,
+        "event_type": event.event_type,
+        "event_type_name": _enum_name(EventType, event.event_type),
+        "event_time": str(event.event_time),
+        "attributes": {},
+    }
+
+    attributes_type = event.WhichOneof("attributes")
+    if attributes_type == "activity_task_scheduled_event_attributes":
+        attrs = event.activity_task_scheduled_event_attributes
+        event_info["attributes"] = {
+            "activity": {
+                "activity_id": attrs.activity_id,
+                "activity_type": attrs.activity_type.name,
+            }
+        }
+    elif attributes_type == "activity_task_failed_event_attributes":
+        attrs = event.activity_task_failed_event_attributes
+        event_info["attributes"] = {
+            "scheduled_event_id": attrs.scheduled_event_id,
+            "started_event_id": attrs.started_event_id,
+            "activity": scheduled_activities.get(attrs.scheduled_event_id),
+            "retry_state": attrs.retry_state,
+            "retry_state_name": _enum_name(RetryState, attrs.retry_state),
+            "failure": _failure_to_metadata(attrs.failure),
+        }
+    elif attributes_type == "start_child_workflow_execution_initiated_event_attributes":
+        attrs = event.start_child_workflow_execution_initiated_event_attributes
+        event_info["attributes"] = {
+            "workflow_task_completed_event_id": attrs.workflow_task_completed_event_id,
+            "workflow": {
+                "workflow_id": attrs.workflow_id,
+                "workflow_type": attrs.workflow_type.name,
+            },
+        }
+    elif attributes_type in {
+        "child_workflow_execution_started_event_attributes",
+        "child_workflow_execution_completed_event_attributes",
+        "child_workflow_execution_failed_event_attributes",
+        "child_workflow_execution_canceled_event_attributes",
+        "child_workflow_execution_terminated_event_attributes",
+    }:
+        attrs = getattr(event, attributes_type)
+        workflow = _child_workflow_metadata(attrs)
+        initiated_workflow = initiated_child_workflows.get(attrs.initiated_event_id)
+        if initiated_workflow:
+            workflow = {**initiated_workflow, **workflow}
+
+        child_attrs: dict[str, Any] = {
+            "initiated_event_id": attrs.initiated_event_id,
+            "started_event_id": getattr(attrs, "started_event_id", None),
+            "workflow": workflow,
+        }
+        if attributes_type == "child_workflow_execution_failed_event_attributes":
+            child_attrs.update(
+                {
+                    "retry_state": attrs.retry_state,
+                    "retry_state_name": _enum_name(RetryState, attrs.retry_state),
+                    "failure": _failure_to_metadata(attrs.failure),
+                }
+            )
+        event_info["attributes"] = child_attrs
+    elif attributes_type == "start_child_workflow_execution_failed_event_attributes":
+        attrs = event.start_child_workflow_execution_failed_event_attributes
+        event_info["attributes"] = {
+            "initiated_event_id": attrs.initiated_event_id,
+            "workflow_task_completed_event_id": attrs.workflow_task_completed_event_id,
+            "cause": attrs.cause,
+            "cause_name": _enum_name(StartChildWorkflowExecutionFailedCause, attrs.cause),
+            "workflow": {
+                "workflow_id": attrs.workflow_id,
+                "workflow_type": attrs.workflow_type.name,
+            },
+        }
+
+    return event_info
+
+
+def _child_workflow_metadata(attrs: Any) -> dict[str, Any]:
+    workflow_execution = attrs.workflow_execution
+    return {
+        "workflow_id": workflow_execution.workflow_id,
+        "run_id": workflow_execution.run_id,
+        "workflow_type": attrs.workflow_type.name,
+    }
+
+
+def _failure_to_metadata(failure: Failure) -> dict[str, Any]:
+    failure_type = failure.WhichOneof("failure_info")
+    result: dict[str, Any] = {
+        "message": failure.message,
+        "source": failure.source,
+        "stack_trace": failure.stack_trace,
+        "type": failure_type.replace("_info", "") if failure_type else None,
+    }
+
+    if failure_type == "application_failure_info":
+        application_info = failure.application_failure_info
+        result["application_failure"] = {
+            "type": application_info.type,
+            "non_retryable": application_info.non_retryable,
+        }
+    elif failure_type == "timeout_failure_info":
+        timeout_info = failure.timeout_failure_info
+        result["timeout_failure"] = {
+            "timeout_type": timeout_info.timeout_type,
+            "timeout_type_name": _enum_name(TimeoutType, timeout_info.timeout_type),
+        }
+    elif failure_type == "server_failure_info":
+        result["server_failure"] = {"non_retryable": failure.server_failure_info.non_retryable}
+    elif failure_type == "activity_failure_info":
+        activity_info = failure.activity_failure_info
+        result["activity_failure"] = {
+            "scheduled_event_id": activity_info.scheduled_event_id,
+            "started_event_id": activity_info.started_event_id,
+            "identity": activity_info.identity,
+            "activity_id": activity_info.activity_id,
+            "activity_type": activity_info.activity_type.name,
+            "retry_state": activity_info.retry_state,
+            "retry_state_name": _enum_name(RetryState, activity_info.retry_state),
+        }
+    elif failure_type == "child_workflow_execution_failure_info":
+        child_workflow_info = failure.child_workflow_execution_failure_info
+        result["child_workflow_failure"] = {
+            "initiated_event_id": child_workflow_info.initiated_event_id,
+            "started_event_id": child_workflow_info.started_event_id,
+            "workflow": {
+                "workflow_id": child_workflow_info.workflow_execution.workflow_id,
+                "run_id": child_workflow_info.workflow_execution.run_id,
+                "workflow_type": child_workflow_info.workflow_type.name,
+            },
+            "retry_state": child_workflow_info.retry_state,
+            "retry_state_name": _enum_name(RetryState, child_workflow_info.retry_state),
+        }
+
+    result["cause"] = _failure_to_metadata(failure.cause) if failure.HasField("cause") else None
+    return result
 
 
 async def get_workflow_event(client: Client, args: dict) -> list[TextContent]:

--- a/tests/test_workflow_handlers.py
+++ b/tests/test_workflow_handlers.py
@@ -5,9 +5,18 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock
 from datetime import datetime, timezone
 from google.protobuf.timestamp_pb2 import Timestamp
-from temporalio.api.common.v1 import ActivityType, Payloads, WorkflowType
-from temporalio.api.enums.v1 import EventType
-from temporalio.api.history.v1 import ActivityTaskCompletedEventAttributes, ActivityTaskScheduledEventAttributes, HistoryEvent, WorkflowExecutionStartedEventAttributes
+from temporalio.api.common.v1 import ActivityType, Payloads, WorkflowExecution, WorkflowType
+from temporalio.api.enums.v1 import EventType, RetryState
+from temporalio.api.failure.v1 import ApplicationFailureInfo, Failure
+from temporalio.api.history.v1 import (
+    ActivityTaskCompletedEventAttributes,
+    ActivityTaskFailedEventAttributes,
+    ActivityTaskScheduledEventAttributes,
+    ChildWorkflowExecutionFailedEventAttributes,
+    HistoryEvent,
+    StartChildWorkflowExecutionInitiatedEventAttributes,
+    WorkflowExecutionStartedEventAttributes,
+)
 from temporalio.converter import default
 
 from temporal_mcp.handlers import workflow_handlers
@@ -168,6 +177,110 @@ class TestGetWorkflowHistory:
         assert response["workflow_id"] == "test-workflow-123"
         assert len(response["events"]) == 2
         assert response["events"][0]["event_type"] == "WorkflowExecutionStarted"
+
+    @pytest.mark.asyncio
+    async def test_get_workflow_history_includes_activity_failure_metadata(self, mock_client):
+        scheduled_event = _history_event(
+            event_id=8,
+            event_type=EventType.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED,
+            activity_task_scheduled_event_attributes=ActivityTaskScheduledEventAttributes(
+                activity_id="delete-volume-claim-abc123",
+                activity_type=ActivityType(name="volume-claim-delete"),
+            ),
+        )
+        failed_event = _history_event(
+            event_id=12,
+            event_type=EventType.EVENT_TYPE_ACTIVITY_TASK_FAILED,
+            activity_task_failed_event_attributes=ActivityTaskFailedEventAttributes(
+                scheduled_event_id=8,
+                started_event_id=10,
+                retry_state=RetryState.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED,
+                failure=Failure(
+                    message="activity failed",
+                    source="PythonSDK",
+                    stack_trace="stack trace",
+                    application_failure_info=ApplicationFailureInfo(type="NullPointerException", non_retryable=False),
+                    cause=Failure(message="root cause", application_failure_info=ApplicationFailureInfo(type="ValueError")),
+                ),
+            ),
+        )
+
+        async def mock_fetch_history_events():
+            for event in [scheduled_event, failed_event]:
+                yield event
+
+        mock_handle = AsyncMock()
+        mock_handle.fetch_history_events = mock_fetch_history_events
+        mock_client.get_workflow_handle = MagicMock(return_value=mock_handle)
+
+        result = await workflow_handlers.get_workflow_history(mock_client, {"workflow_id": "test-workflow-123"})
+
+        response = json.loads(result[0].text)
+        failed_attrs = response["events"][1]["attributes"]
+
+        assert response["events"][1]["event_type_name"] == "EVENT_TYPE_ACTIVITY_TASK_FAILED"
+        assert failed_attrs["scheduled_event_id"] == 8
+        assert failed_attrs["started_event_id"] == 10
+        assert failed_attrs["activity"] == {"activity_id": "delete-volume-claim-abc123", "activity_type": "volume-claim-delete"}
+        assert failed_attrs["retry_state"] == RetryState.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED
+        assert failed_attrs["retry_state_name"] == "RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED"
+        assert failed_attrs["failure"]["message"] == "activity failed"
+        assert failed_attrs["failure"]["source"] == "PythonSDK"
+        assert failed_attrs["failure"]["stack_trace"] == "stack trace"
+        assert failed_attrs["failure"]["type"] == "application_failure"
+        assert failed_attrs["failure"]["application_failure"] == {"type": "NullPointerException", "non_retryable": False}
+        assert failed_attrs["failure"]["cause"]["message"] == "root cause"
+        assert "__raw__" not in failed_attrs
+        assert "input" not in failed_attrs
+
+    @pytest.mark.asyncio
+    async def test_get_workflow_history_includes_child_workflow_metadata(self, mock_client):
+        initiated_event = _history_event(
+            event_id=5,
+            event_type=EventType.EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED,
+            start_child_workflow_execution_initiated_event_attributes=StartChildWorkflowExecutionInitiatedEventAttributes(
+                workflow_id="child-workflow-id",
+                workflow_type=WorkflowType(name="ChildWorkflow"),
+                workflow_task_completed_event_id=4,
+            ),
+        )
+        failed_event = _history_event(
+            event_id=9,
+            event_type=EventType.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_FAILED,
+            child_workflow_execution_failed_event_attributes=ChildWorkflowExecutionFailedEventAttributes(
+                initiated_event_id=5,
+                started_event_id=6,
+                workflow_execution=WorkflowExecution(workflow_id="child-workflow-id", run_id="child-run-id"),
+                workflow_type=WorkflowType(name="ChildWorkflow"),
+                retry_state=RetryState.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED,
+                failure=Failure(message="child failed", application_failure_info=ApplicationFailureInfo(type="ChildError")),
+            ),
+        )
+
+        async def mock_fetch_history_events():
+            for event in [initiated_event, failed_event]:
+                yield event
+
+        mock_handle = AsyncMock()
+        mock_handle.fetch_history_events = mock_fetch_history_events
+        mock_client.get_workflow_handle = MagicMock(return_value=mock_handle)
+
+        result = await workflow_handlers.get_workflow_history(mock_client, {"workflow_id": "parent-workflow-id"})
+
+        response = json.loads(result[0].text)
+        initiated_attrs = response["events"][0]["attributes"]
+        failed_attrs = response["events"][1]["attributes"]
+
+        assert initiated_attrs["workflow_task_completed_event_id"] == 4
+        assert initiated_attrs["workflow"] == {"workflow_id": "child-workflow-id", "workflow_type": "ChildWorkflow"}
+        assert response["events"][1]["event_type_name"] == "EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_FAILED"
+        assert failed_attrs["initiated_event_id"] == 5
+        assert failed_attrs["started_event_id"] == 6
+        assert failed_attrs["workflow"] == {"workflow_id": "child-workflow-id", "workflow_type": "ChildWorkflow", "run_id": "child-run-id"}
+        assert failed_attrs["retry_state_name"] == "RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED"
+        assert failed_attrs["failure"]["application_failure"] == {"type": "ChildError", "non_retryable": False}
+        assert "__raw__" not in failed_attrs
+        assert "result" not in failed_attrs
 
 
 class TestGetWorkflowEvent:


### PR DESCRIPTION
## Summary
Adds metadata-only enrichment to `get_workflow_history` so callers can trace failed activities and child workflows without decoding payloads.

Closes #38.

## What changed
- Adds `event_type_name` for history events.
- Adds curated `attributes` for activity failures, child workflow events, and child workflow start failures.
- Correlates failed activities with their scheduled activity metadata.
- Includes retry state names, failure metadata, application failure details, and recursive causes.
- Keeps payloads and raw proto fallbacks out of the history response.

## Tests
- `pytest -q`
- `black --check temporal_mcp/handlers/workflow_handlers.py tests/test_workflow_handlers.py`
- `flake8 temporal_mcp/handlers/workflow_handlers.py tests/test_workflow_handlers.py`
- `mypy temporal_mcp/handlers/workflow_handlers.py tests/test_workflow_handlers.py`
- `git diff --check`
