### PR TITLE
Expand schedule descriptions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write
     outputs:
-      released: ${{ steps.version_check.outputs.will_release }}
+      released: ${{ steps.semantic_release.outputs.released }}
 
     steps:
       - name: Checkout
@@ -30,28 +30,26 @@ jobs:
       - name: Install tools
         run: pip install python-semantic-release build
 
-      - name: Check for releasable commits
-        id: version_check
-        run: |
-          version=$(semantic-release version --print 2>/dev/null || true)
-          if [ -n "$version" ]; then
-            echo "will_release=true" >> $GITHUB_OUTPUT
-          else
-            echo "will_release=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Run semantic release
-        if: steps.version_check.outputs.will_release == 'true'
+        id: semantic_release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: semantic-release version --push
+        run: |
+          output=$(semantic-release version --push 2>&1)
+          echo "$output"
+
+          if echo "$output" | grep -q "No release will be made"; then
+            echo "released=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "released=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Build package
-        if: steps.version_check.outputs.will_release == 'true'
+        if: steps.semantic_release.outputs.released == 'true'
         run: python -m build
 
       - name: Upload build artifacts
-        if: steps.version_check.outputs.will_release == 'true'
+        if: steps.semantic_release.outputs.released == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: dist

--- a/temporal_mcp/handlers/schedule_handlers.py
+++ b/temporal_mcp/handlers/schedule_handlers.py
@@ -1,10 +1,15 @@
 """Handlers for schedule operations."""
 
+import dataclasses
 import json
 import sys
+from datetime import datetime, timedelta
+from enum import Enum
+from typing import Any
 
 from mcp.types import TextContent
-from temporalio.client import Client, Schedule, ScheduleActionStartWorkflow, ScheduleSpec, ScheduleDescription
+from temporalio.api.common.v1 import Payload
+from temporalio.client import Client, Schedule, ScheduleActionExecutionStartWorkflow, ScheduleActionStartWorkflow, ScheduleSpec, ScheduleDescription
 
 
 async def create_schedule(client: Client, args: dict) -> list[TextContent]:
@@ -191,18 +196,13 @@ async def describe_schedule(client: Client, args: dict) -> list[TextContent]:
     sched = desc.schedule
     info = desc.info
 
-    action_info: dict = {}
-    if isinstance(sched.action, ScheduleActionStartWorkflow):
-        action_info = {
-            "workflow": sched.action.workflow,
-            "task_queue": sched.action.task_queue,
-            "workflow_execution_id": sched.action.id,
-        }
+    action_info = _schedule_action_to_dict(sched.action)
 
     recent_actions = [
         {
             "scheduled_at": r.scheduled_at.isoformat(),
             "started_at": r.started_at.isoformat(),
+            "action": _schedule_action_execution_to_dict(r.action),
         }
         for r in info.recent_actions
     ]
@@ -211,9 +211,7 @@ async def describe_schedule(client: Client, args: dict) -> list[TextContent]:
 
     result = {
         "schedule_id": desc.id,
-        "spec": {
-            "cron_expressions": list(sched.spec.cron_expressions),
-        },
+        "spec": _schedule_spec_to_dict(sched.spec),
         "action": action_info,
         "state": {
             "paused": sched.state.paused,
@@ -225,6 +223,7 @@ async def describe_schedule(client: Client, args: dict) -> list[TextContent]:
             "num_actions": info.num_actions,
             "num_actions_missed_catchup_window": info.num_actions_missed_catchup_window,
             "num_actions_skipped_overlap": info.num_actions_skipped_overlap,
+            "running_actions": [_schedule_action_execution_to_dict(action) for action in info.running_actions],
             "recent_actions": recent_actions,
             "next_action_times": next_action_times,
             "created_at": info.created_at.isoformat(),
@@ -233,3 +232,114 @@ async def describe_schedule(client: Client, args: dict) -> list[TextContent]:
     }
 
     return [TextContent(type="text", text=json.dumps(result, indent=2))]
+
+
+def _schedule_spec_to_dict(spec: ScheduleSpec) -> dict[str, Any]:
+    return {
+        "calendars": [_calendar_spec_to_dict(calendar) for calendar in spec.calendars],
+        "intervals": [_interval_spec_to_dict(interval) for interval in spec.intervals],
+        "cron_expressions": list(spec.cron_expressions),
+        "skip": [_calendar_spec_to_dict(calendar) for calendar in spec.skip],
+        "start_at": spec.start_at.isoformat() if spec.start_at else None,
+        "end_at": spec.end_at.isoformat() if spec.end_at else None,
+        "jitter": _timedelta_to_seconds(spec.jitter),
+        "time_zone_name": spec.time_zone_name,
+    }
+
+
+def _calendar_spec_to_dict(calendar: Any) -> dict[str, Any]:
+    return {
+        "second": [_range_to_dict(r) for r in calendar.second],
+        "minute": [_range_to_dict(r) for r in calendar.minute],
+        "hour": [_range_to_dict(r) for r in calendar.hour],
+        "day_of_month": [_range_to_dict(r) for r in calendar.day_of_month],
+        "month": [_range_to_dict(r) for r in calendar.month],
+        "year": [_range_to_dict(r) for r in calendar.year],
+        "day_of_week": [_range_to_dict(r) for r in calendar.day_of_week],
+        "comment": calendar.comment,
+    }
+
+
+def _range_to_dict(schedule_range: Any) -> dict[str, int]:
+    return {
+        "start": schedule_range.start,
+        "end": schedule_range.end,
+        "step": schedule_range.step,
+    }
+
+
+def _interval_spec_to_dict(interval: Any) -> dict[str, float | None]:
+    return {
+        "every": _timedelta_to_seconds(interval.every),
+        "offset": _timedelta_to_seconds(interval.offset),
+    }
+
+
+def _schedule_action_to_dict(action: Any) -> dict[str, Any]:
+    if isinstance(action, ScheduleActionStartWorkflow):
+        result = {
+            "workflow": action.workflow,
+            "task_queue": action.task_queue,
+            "workflow_execution_id": action.id,
+            "args": _json_safe(action.args),
+            "execution_timeout": _timedelta_to_seconds(action.execution_timeout),
+            "run_timeout": _timedelta_to_seconds(action.run_timeout),
+            "task_timeout": _timedelta_to_seconds(action.task_timeout),
+            "retry_policy": _json_safe(action.retry_policy),
+            "memo": _json_safe(action.memo),
+            "search_attributes": _search_attributes_to_dict(action.typed_search_attributes, action.untyped_search_attributes),
+            "static_summary": _json_safe(action.static_summary),
+            "static_details": _json_safe(action.static_details),
+            "priority": _json_safe(action.priority),
+        }
+        if action.headers:
+            result["headers"] = _json_safe(action.headers)
+        return result
+    return {}
+
+
+def _schedule_action_execution_to_dict(action: Any) -> dict[str, Any]:
+    if isinstance(action, ScheduleActionExecutionStartWorkflow):
+        return {
+            "workflow_id": action.workflow_id,
+            "first_execution_run_id": action.first_execution_run_id,
+        }
+    return {}
+
+
+def _search_attributes_to_dict(typed_search_attributes: Any, untyped_search_attributes: Any) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    if typed_search_attributes and getattr(typed_search_attributes, "search_attributes", None):
+        result["typed"] = _json_safe(typed_search_attributes)
+    if untyped_search_attributes:
+        result["untyped"] = _json_safe(untyped_search_attributes)
+    return result
+
+
+def _timedelta_to_seconds(value: timedelta | None) -> float | None:
+    return value.total_seconds() if value else None
+
+
+def _json_safe(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, timedelta):
+        return value.total_seconds()
+    if isinstance(value, Enum):
+        return value.name
+    if isinstance(value, Payload):
+        return {
+            "metadata": {key: metadata_value.decode("utf-8", errors="replace") for key, metadata_value in value.metadata.items()},
+            "data_size": len(value.data),
+        }
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_safe(item) for item in value]
+    if hasattr(value, "_asdict"):
+        return _json_safe(value._asdict())
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return {field.name: _json_safe(getattr(value, field.name)) for field in dataclasses.fields(value)}
+    return str(value)

--- a/tests/test_schedule_handlers.py
+++ b/tests/test_schedule_handlers.py
@@ -2,7 +2,7 @@
 
 import json
 import pytest
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 from temporal_mcp.handlers import schedule_handlers
@@ -108,18 +108,17 @@ class TestScheduleHandlers:
 
     @pytest.mark.asyncio
     async def test_describe_schedule_success(self, mock_client):
-        from temporalio.client import ScheduleActionStartWorkflow
+        from temporalio.client import ScheduleActionStartWorkflow, ScheduleSpec
 
         now = datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
         next_time = datetime(2024, 1, 16, 9, 0, 0, tzinfo=timezone.utc)
 
-        mock_action = MagicMock(spec=ScheduleActionStartWorkflow)
-        mock_action.workflow = "TestWorkflow"
-        mock_action.task_queue = "test-queue"
-        mock_action.id = "test-schedule-workflow"
-
-        mock_spec = MagicMock()
-        mock_spec.cron_expressions = ["0 9 * * *"]
+        mock_action = ScheduleActionStartWorkflow(
+            "TestWorkflow",
+            args=[],
+            id="test-schedule-workflow",
+            task_queue="test-queue",
+        )
 
         mock_state = MagicMock()
         mock_state.paused = False
@@ -129,7 +128,7 @@ class TestScheduleHandlers:
 
         mock_schedule = MagicMock()
         mock_schedule.action = mock_action
-        mock_schedule.spec = mock_spec
+        mock_schedule.spec = ScheduleSpec(cron_expressions=["0 9 * * *"])
         mock_schedule.state = mock_state
 
         mock_recent_action = MagicMock()
@@ -140,6 +139,7 @@ class TestScheduleHandlers:
         mock_info.num_actions = 5
         mock_info.num_actions_missed_catchup_window = 0
         mock_info.num_actions_skipped_overlap = 1
+        mock_info.running_actions = []
         mock_info.recent_actions = [mock_recent_action]
         mock_info.next_action_times = [next_time]
         mock_info.created_at = now
@@ -167,6 +167,7 @@ class TestScheduleHandlers:
         assert response["state"]["note"] is None
         assert response["info"]["num_actions"] == 5
         assert response["info"]["num_actions_skipped_overlap"] == 1
+        assert response["info"]["running_actions"] == []
         assert len(response["info"]["recent_actions"]) == 1
         assert response["info"]["recent_actions"][0]["scheduled_at"] == now.isoformat()
         assert response["info"]["next_action_times"] == [next_time.isoformat()]
@@ -176,18 +177,17 @@ class TestScheduleHandlers:
 
     @pytest.mark.asyncio
     async def test_describe_schedule_with_last_updated_at(self, mock_client):
-        from temporalio.client import ScheduleActionStartWorkflow
+        from temporalio.client import ScheduleActionStartWorkflow, ScheduleSpec
 
         now = datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
         updated = datetime(2024, 1, 20, 12, 0, 0, tzinfo=timezone.utc)
 
-        mock_action = MagicMock(spec=ScheduleActionStartWorkflow)
-        mock_action.workflow = "TestWorkflow"
-        mock_action.task_queue = "test-queue"
-        mock_action.id = "test-schedule-workflow"
-
-        mock_spec = MagicMock()
-        mock_spec.cron_expressions = ["0 12 * * *"]
+        mock_action = ScheduleActionStartWorkflow(
+            "TestWorkflow",
+            args=[],
+            id="test-schedule-workflow",
+            task_queue="test-queue",
+        )
 
         mock_state = MagicMock()
         mock_state.paused = True
@@ -197,13 +197,14 @@ class TestScheduleHandlers:
 
         mock_schedule = MagicMock()
         mock_schedule.action = mock_action
-        mock_schedule.spec = mock_spec
+        mock_schedule.spec = ScheduleSpec(cron_expressions=["0 12 * * *"])
         mock_schedule.state = mock_state
 
         mock_info = MagicMock()
         mock_info.num_actions = 10
         mock_info.num_actions_missed_catchup_window = 2
         mock_info.num_actions_skipped_overlap = 0
+        mock_info.running_actions = []
         mock_info.recent_actions = []
         mock_info.next_action_times = []
         mock_info.created_at = now
@@ -227,3 +228,106 @@ class TestScheduleHandlers:
         assert response["state"]["note"] == "Paused for maintenance"
         assert response["info"]["num_actions_missed_catchup_window"] == 2
         assert response["info"]["last_updated_at"] == updated.isoformat()
+
+    @pytest.mark.asyncio
+    async def test_describe_schedule_includes_extended_fields(self, mock_client):
+        from temporalio.client import ScheduleActionExecutionStartWorkflow, ScheduleActionResult, ScheduleActionStartWorkflow, ScheduleCalendarSpec, ScheduleIntervalSpec, ScheduleRange, ScheduleSpec
+        from temporalio.common import RetryPolicy
+
+        now = datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        start_at = datetime(2024, 1, 16, 9, 0, 0, tzinfo=timezone.utc)
+        end_at = datetime(2024, 2, 16, 9, 0, 0, tzinfo=timezone.utc)
+        action_execution = ScheduleActionExecutionStartWorkflow(
+            workflow_id="child-workflow-id",
+            first_execution_run_id="run-123",
+        )
+
+        mock_state = MagicMock()
+        mock_state.paused = False
+        mock_state.note = None
+        mock_state.limited_actions = False
+        mock_state.remaining_actions = 0
+
+        mock_schedule = MagicMock()
+        mock_schedule.action = ScheduleActionStartWorkflow(
+            "TestWorkflow",
+            args=[{"customer_id": "123"}],
+            id="test-schedule-workflow",
+            task_queue="test-queue",
+            execution_timeout=timedelta(minutes=30),
+            run_timeout=timedelta(minutes=20),
+            task_timeout=timedelta(seconds=30),
+            retry_policy=RetryPolicy(maximum_attempts=3, non_retryable_error_types=["BadRequest"]),
+            memo={"owner": "platform"},
+            untyped_search_attributes={"CustomKeywordField": ["nightly"]},
+            static_summary="Nightly schedule",
+            static_details="Runs every night",
+        )
+        mock_schedule.spec = ScheduleSpec(
+            calendars=[
+                ScheduleCalendarSpec(
+                    minute=[ScheduleRange(15)],
+                    hour=[ScheduleRange(2)],
+                    comment="2:15 AM",
+                )
+            ],
+            intervals=[ScheduleIntervalSpec(every=timedelta(hours=6), offset=timedelta(minutes=30))],
+            cron_expressions=["15 2 * * *"],
+            skip=[ScheduleCalendarSpec(day_of_week=[ScheduleRange(0)], comment="skip sunday")],
+            start_at=start_at,
+            end_at=end_at,
+            jitter=timedelta(minutes=5),
+            time_zone_name="America/New_York",
+        )
+        mock_schedule.state = mock_state
+
+        mock_info = MagicMock()
+        mock_info.num_actions = 5
+        mock_info.num_actions_missed_catchup_window = 0
+        mock_info.num_actions_skipped_overlap = 0
+        mock_info.running_actions = [action_execution]
+        mock_info.recent_actions = [
+            ScheduleActionResult(
+                scheduled_at=now,
+                started_at=now,
+                action=action_execution,
+            )
+        ]
+        mock_info.next_action_times = []
+        mock_info.created_at = now
+        mock_info.last_updated_at = now
+
+        mock_description = MagicMock()
+        mock_description.id = "test-schedule"
+        mock_description.schedule = mock_schedule
+        mock_description.info = mock_info
+
+        mock_handle = MagicMock()
+        mock_handle.describe = AsyncMock(return_value=mock_description)
+        mock_client.get_schedule_handle = MagicMock(return_value=mock_handle)
+
+        result = await schedule_handlers.describe_schedule(mock_client, {"schedule_id": "test-schedule"})
+
+        response = json.loads(result[0].text)
+
+        assert response["spec"]["calendars"][0]["minute"] == [{"start": 15, "end": 15, "step": 1}]
+        assert response["spec"]["calendars"][0]["hour"] == [{"start": 2, "end": 2, "step": 1}]
+        assert response["spec"]["calendars"][0]["comment"] == "2:15 AM"
+        assert response["spec"]["intervals"] == [{"every": 21600.0, "offset": 1800.0}]
+        assert response["spec"]["skip"][0]["comment"] == "skip sunday"
+        assert response["spec"]["start_at"] == start_at.isoformat()
+        assert response["spec"]["end_at"] == end_at.isoformat()
+        assert response["spec"]["jitter"] == 300.0
+        assert response["spec"]["time_zone_name"] == "America/New_York"
+        assert response["action"]["args"] == [{"customer_id": "123"}]
+        assert response["action"]["memo"] == {"owner": "platform"}
+        assert response["action"]["retry_policy"]["maximum_attempts"] == 3
+        assert response["action"]["retry_policy"]["non_retryable_error_types"] == ["BadRequest"]
+        assert response["action"]["search_attributes"]["untyped"] == {"CustomKeywordField": ["nightly"]}
+        assert response["action"]["execution_timeout"] == 1800.0
+        assert response["action"]["run_timeout"] == 1200.0
+        assert response["action"]["task_timeout"] == 30.0
+        assert response["action"]["static_summary"] == "Nightly schedule"
+        assert response["action"]["static_details"] == "Runs every night"
+        assert response["info"]["running_actions"] == [{"workflow_id": "child-workflow-id", "first_execution_run_id": "run-123"}]
+        assert response["info"]["recent_actions"][0]["action"] == {"workflow_id": "child-workflow-id", "first_execution_run_id": "run-123"}


### PR DESCRIPTION
## Summary

Closes #35.

Expands `describe_schedule` so schedules created outside the cron-only MCP tool retain fuller Temporal SDK detail in descriptions.

## What changed

- Adds `ScheduleSpec` fields for calendars, intervals, skip calendars, start and end times, jitter, and time zone.
- Adds workflow action details including args, memo, retry policy, search attributes, timeouts, summary, details, and priority.
- Adds `running_actions` and includes action execution details on recent actions.
- Fixes the release workflow so PyPI publish only runs when semantic-release actually creates a new release.

## Example fields

```json
{
  "spec": {
    "calendars": [{"hour": [{"start": 2, "end": 2, "step": 1}]}],
    "intervals": [{"every": 21600.0, "offset": 1800.0}],
    "time_zone_name": "America/New_York"
  },
  "action": {
    "args": [{"customer_id": "123"}],
    "retry_policy": {"maximum_attempts": 3},
    "memo": {"owner": "platform"}
  },
  "info": {
    "running_actions": [{"workflow_id": "child-workflow-id", "first_execution_run_id": "run-123"}]
  }
}
```

## Tests

- `pytest tests/test_schedule_handlers.py -q`
- `pytest -q`
- `black --check .`
- `flake8 .`
- `mypy temporal_mcp tests`
- `python -c "import pathlib, yaml; [yaml.safe_load(p.read_text()) for p in pathlib.Path('.github/workflows').glob('*.yml')]; print('workflow yaml parsed')"`
- `docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:latest .github/workflows/release.yml`
