### PR TITLE
feat: support MCP SDK 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 dependencies = [
     "temporalio>=1.5.0",
-    "mcp>=1.28.1,<2.0.0",
+    "mcp>=2.0.0",
     "idna>=3.15",
     "python-multipart>=0.0.31",
     "asyncio-atexit>=1.0.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 temporalio>=1.5.0
 
 # Model Context Protocol
-mcp>=1.28.1,<2.0.0
+mcp>=2.0.0
 
 # Security floors for transitive runtime dependencies
 idna>=3.15

--- a/temporal_mcp/server.py
+++ b/temporal_mcp/server.py
@@ -1,11 +1,11 @@
 """Main MCP Server for Temporal workflow orchestration."""
 
 import json
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
-from mcp.types import CallToolRequestParams, CallToolResult, ListToolsResult, TextContent
+from mcp.types import CallToolRequestParams, CallToolResult, ContentBlock, ListToolsResult, TextContent
 
 from .client import TemporalClientManager
 from .tools.tool_definitions import get_all_tools
@@ -62,7 +62,7 @@ class TemporalMCPServer:
     async def _call_tool(self, context: Any, params: CallToolRequestParams) -> CallToolResult:
         """Handle tool execution requests."""
         content = await self._execute_tool(params.name, params.arguments or {})
-        return CallToolResult(content=content)
+        return CallToolResult(content=cast(list[ContentBlock], content))
 
     async def _execute_tool(self, name: str, arguments: Any) -> list[TextContent]:
         """Execute a Temporal tool by name."""

--- a/temporal_mcp/server.py
+++ b/temporal_mcp/server.py
@@ -5,7 +5,7 @@ from typing import Any, Optional
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
-from mcp.types import Tool, TextContent
+from mcp.types import CallToolRequestParams, CallToolResult, ListToolsResult, TextContent
 
 from .client import TemporalClientManager
 from .tools.tool_definitions import get_all_tools
@@ -49,107 +49,110 @@ class TemporalMCPServer:
             tls_client_key_path=tls_client_key_path,
             api_key=api_key,
         )
-        self.server = Server("temporal-mcp-server")
-        self._setup_handlers()
+        self.server = Server(
+            "temporal-mcp-server",
+            on_list_tools=self._list_tools,
+            on_call_tool=self._call_tool,
+        )
 
-    def _setup_handlers(self):
-        """Set up MCP request handlers."""
+    async def _list_tools(self, context: Any, params: Any) -> ListToolsResult:
+        """List available Temporal tools."""
+        return ListToolsResult(tools=get_all_tools())
 
-        @self.server.list_tools()
-        async def list_tools() -> list[Tool]:
-            """List available Temporal tools."""
-            return get_all_tools()
+    async def _call_tool(self, context: Any, params: CallToolRequestParams) -> CallToolResult:
+        """Handle tool execution requests."""
+        content = await self._execute_tool(params.name, params.arguments or {})
+        return CallToolResult(content=content)
 
-        @self.server.call_tool()
-        async def call_tool(name: str, arguments: Any) -> list[TextContent]:
-            """Handle tool execution requests."""
-            # Ensure connection
-            try:
-                await self.client_manager.connect()
-            except Exception as e:
-                return format_connection_error(e)
+    async def _execute_tool(self, name: str, arguments: Any) -> list[TextContent]:
+        """Execute a Temporal tool by name."""
+        # Ensure connection
+        try:
+            await self.client_manager.connect()
+        except Exception as e:
+            return format_connection_error(e)
 
-            # Route to appropriate handler
-            try:
-                client = self.client_manager.ensure_connected()
+        # Route to appropriate handler
+        try:
+            client = self.client_manager.ensure_connected()
 
-                # Workflow operations
-                if name == "start_workflow":
-                    return await workflow_handlers.start_workflow(client, arguments)
-                elif name == "cancel_workflow":
-                    return await workflow_handlers.cancel_workflow(client, arguments)
-                elif name == "terminate_workflow":
-                    return await workflow_handlers.terminate_workflow(client, arguments)
-                elif name == "get_workflow_result":
-                    return await workflow_handlers.get_workflow_result(client, arguments)
-                elif name == "describe_workflow":
-                    return await workflow_handlers.describe_workflow(client, arguments)
-                elif name == "list_workflows":
-                    return await workflow_handlers.list_workflows(client, arguments)
-                elif name == "get_workflow_history":
-                    return await workflow_handlers.get_workflow_history(client, arguments)
-                elif name == "get_workflow_event":
-                    return await workflow_handlers.get_workflow_event(client, arguments)
+            # Workflow operations
+            if name == "start_workflow":
+                return await workflow_handlers.start_workflow(client, arguments)
+            elif name == "cancel_workflow":
+                return await workflow_handlers.cancel_workflow(client, arguments)
+            elif name == "terminate_workflow":
+                return await workflow_handlers.terminate_workflow(client, arguments)
+            elif name == "get_workflow_result":
+                return await workflow_handlers.get_workflow_result(client, arguments)
+            elif name == "describe_workflow":
+                return await workflow_handlers.describe_workflow(client, arguments)
+            elif name == "list_workflows":
+                return await workflow_handlers.list_workflows(client, arguments)
+            elif name == "get_workflow_history":
+                return await workflow_handlers.get_workflow_history(client, arguments)
+            elif name == "get_workflow_event":
+                return await workflow_handlers.get_workflow_event(client, arguments)
 
-                # Standalone activity operations
-                elif name == "start_activity":
-                    return await activity_handlers.start_activity(client, arguments)
-                elif name == "execute_activity":
-                    return await activity_handlers.execute_activity(client, arguments)
-                elif name == "get_activity_result":
-                    return await activity_handlers.get_activity_result(client, arguments)
-                elif name == "describe_activity":
-                    return await activity_handlers.describe_activity(client, arguments)
-                elif name == "list_activities":
-                    return await activity_handlers.list_activities(client, arguments)
-                elif name == "count_activities":
-                    return await activity_handlers.count_activities(client, arguments)
-                elif name == "cancel_activity":
-                    return await activity_handlers.cancel_activity(client, arguments)
-                elif name == "terminate_activity":
-                    return await activity_handlers.terminate_activity(client, arguments)
+            # Standalone activity operations
+            elif name == "start_activity":
+                return await activity_handlers.start_activity(client, arguments)
+            elif name == "execute_activity":
+                return await activity_handlers.execute_activity(client, arguments)
+            elif name == "get_activity_result":
+                return await activity_handlers.get_activity_result(client, arguments)
+            elif name == "describe_activity":
+                return await activity_handlers.describe_activity(client, arguments)
+            elif name == "list_activities":
+                return await activity_handlers.list_activities(client, arguments)
+            elif name == "count_activities":
+                return await activity_handlers.count_activities(client, arguments)
+            elif name == "cancel_activity":
+                return await activity_handlers.cancel_activity(client, arguments)
+            elif name == "terminate_activity":
+                return await activity_handlers.terminate_activity(client, arguments)
 
-                # Query and signal operations
-                elif name == "query_workflow":
-                    return await query_handlers.query_workflow(client, arguments)
-                elif name == "signal_workflow":
-                    return await query_handlers.signal_workflow(client, arguments)
-                elif name == "continue_as_new":
-                    return await query_handlers.continue_as_new(client, arguments)
+            # Query and signal operations
+            elif name == "query_workflow":
+                return await query_handlers.query_workflow(client, arguments)
+            elif name == "signal_workflow":
+                return await query_handlers.signal_workflow(client, arguments)
+            elif name == "continue_as_new":
+                return await query_handlers.continue_as_new(client, arguments)
 
-                # Batch operations
-                elif name == "batch_signal":
-                    return await batch_handlers.batch_signal(client, arguments)
-                elif name == "batch_cancel":
-                    return await batch_handlers.batch_cancel(client, arguments)
-                elif name == "batch_terminate":
-                    return await batch_handlers.batch_terminate(client, arguments)
-                elif name == "batch_cancel_activities":
-                    return await batch_handlers.batch_cancel_activities(client, arguments)
-                elif name == "batch_terminate_activities":
-                    return await batch_handlers.batch_terminate_activities(client, arguments)
+            # Batch operations
+            elif name == "batch_signal":
+                return await batch_handlers.batch_signal(client, arguments)
+            elif name == "batch_cancel":
+                return await batch_handlers.batch_cancel(client, arguments)
+            elif name == "batch_terminate":
+                return await batch_handlers.batch_terminate(client, arguments)
+            elif name == "batch_cancel_activities":
+                return await batch_handlers.batch_cancel_activities(client, arguments)
+            elif name == "batch_terminate_activities":
+                return await batch_handlers.batch_terminate_activities(client, arguments)
 
-                # Schedule operations
-                elif name == "create_schedule":
-                    return await schedule_handlers.create_schedule(client, arguments)
-                elif name == "list_schedules":
-                    return await schedule_handlers.list_schedules(client, arguments)
-                elif name == "pause_schedule":
-                    return await schedule_handlers.pause_schedule(client, arguments)
-                elif name == "unpause_schedule":
-                    return await schedule_handlers.unpause_schedule(client, arguments)
-                elif name == "delete_schedule":
-                    return await schedule_handlers.delete_schedule(client, arguments)
-                elif name == "trigger_schedule":
-                    return await schedule_handlers.trigger_schedule(client, arguments)
-                elif name == "describe_schedule":
-                    return await schedule_handlers.describe_schedule(client, arguments)
+            # Schedule operations
+            elif name == "create_schedule":
+                return await schedule_handlers.create_schedule(client, arguments)
+            elif name == "list_schedules":
+                return await schedule_handlers.list_schedules(client, arguments)
+            elif name == "pause_schedule":
+                return await schedule_handlers.pause_schedule(client, arguments)
+            elif name == "unpause_schedule":
+                return await schedule_handlers.unpause_schedule(client, arguments)
+            elif name == "delete_schedule":
+                return await schedule_handlers.delete_schedule(client, arguments)
+            elif name == "trigger_schedule":
+                return await schedule_handlers.trigger_schedule(client, arguments)
+            elif name == "describe_schedule":
+                return await schedule_handlers.describe_schedule(client, arguments)
 
-                else:
-                    return [TextContent(type="text", text=json.dumps({"error": f"Unknown tool: {name}", "type": "unknown_tool"}, indent=2))]
+            else:
+                return [TextContent(type="text", text=json.dumps({"error": f"Unknown tool: {name}", "type": "unknown_tool"}, indent=2))]
 
-            except Exception as e:
-                return format_error_response(e, name)
+        except Exception as e:
+            return format_error_response(e, name)
 
     async def run(self):
         """Run the MCP server."""

--- a/temporal_mcp/server.py
+++ b/temporal_mcp/server.py
@@ -1,7 +1,7 @@
 """Main MCP Server for Temporal workflow orchestration."""
 
 import json
-from typing import Any, Optional, cast
+from typing import Any, Optional, Sequence
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
@@ -61,10 +61,10 @@ class TemporalMCPServer:
 
     async def _call_tool(self, context: Any, params: CallToolRequestParams) -> CallToolResult:
         """Handle tool execution requests."""
-        content = await self._execute_tool(params.name, params.arguments or {})
-        return CallToolResult(content=cast(list[ContentBlock], content))
+        content = list(await self._execute_tool(params.name, params.arguments or {}))
+        return CallToolResult(content=content)
 
-    async def _execute_tool(self, name: str, arguments: Any) -> list[TextContent]:
+    async def _execute_tool(self, name: str, arguments: Any) -> Sequence[ContentBlock]:
         """Execute a Temporal tool by name."""
         # Ensure connection
         try:

--- a/temporal_mcp/tools/tool_definitions.py
+++ b/temporal_mcp/tools/tool_definitions.py
@@ -13,7 +13,7 @@ def get_all_tools() -> list[Tool]:
         Tool(
             name="start_workflow",
             description="Start a new Temporal workflow execution",
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "workflow_name": {"type": "string", "description": "The name of the workflow to start"},
@@ -27,7 +27,7 @@ def get_all_tools() -> list[Tool]:
         Tool(
             name="query_workflow",
             description="Query a running workflow for its current state",
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "workflow_id": {"type": "string", "description": "The workflow execution ID to query"},
@@ -40,7 +40,7 @@ def get_all_tools() -> list[Tool]:
         Tool(
             name="signal_workflow",
             description="Send a signal to a running workflow",
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "workflow_id": {"type": "string", "description": "The workflow execution ID to signal"},
@@ -53,22 +53,22 @@ def get_all_tools() -> list[Tool]:
         Tool(
             name="cancel_workflow",
             description="Cancel a running workflow execution",
-            inputSchema={"type": "object", "properties": {"workflow_id": {"type": "string", "description": "The workflow execution ID to cancel"}}, "required": ["workflow_id"]},
+            input_schema={"type": "object", "properties": {"workflow_id": {"type": "string", "description": "The workflow execution ID to cancel"}}, "required": ["workflow_id"]},
         ),
         Tool(
             name="get_workflow_result",
             description="Get the result of a completed workflow",
-            inputSchema={"type": "object", "properties": {"workflow_id": {"type": "string", "description": "The workflow execution ID"}}, "required": ["workflow_id"]},
+            input_schema={"type": "object", "properties": {"workflow_id": {"type": "string", "description": "The workflow execution ID"}}, "required": ["workflow_id"]},
         ),
         Tool(
             name="describe_workflow",
             description="Get detailed information about a workflow execution",
-            inputSchema={"type": "object", "properties": {"workflow_id": {"type": "string", "description": "The workflow execution ID to describe"}}, "required": ["workflow_id"]},
+            input_schema={"type": "object", "properties": {"workflow_id": {"type": "string", "description": "The workflow execution ID to describe"}}, "required": ["workflow_id"]},
         ),
         Tool(
             name="list_workflows",
             description="List workflow executions based on a query. Specify 'limit' to control the number of results (default: 100, max recommended: 1000). Use 'skip' to paginate through results.",
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "query": {"type": "string", "description": "List filter query (e.g., 'WorkflowType=\"MyWorkflow\"')"},
@@ -80,7 +80,7 @@ def get_all_tools() -> list[Tool]:
         Tool(
             name="terminate_workflow",
             description="Forcefully terminate a workflow execution",
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {"workflow_id": {"type": "string", "description": "The workflow execution ID to terminate"}, "reason": {"type": "string", "description": "Reason for termination"}},
                 "required": ["workflow_id"],
@@ -89,7 +89,7 @@ def get_all_tools() -> list[Tool]:
         Tool(
             name="get_workflow_history",
             description="Get the complete event history of a workflow execution. Specify 'limit' to control the number of events (default: 1000).",
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "workflow_id": {"type": "string", "description": "The workflow execution ID"},
@@ -101,7 +101,7 @@ def get_all_tools() -> list[Tool]:
         Tool(
             name="get_workflow_event",
             description="Get a single workflow history event with decoded payload fields when present",
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "workflow_id": {"type": "string", "description": "The workflow execution ID"},
@@ -114,7 +114,7 @@ def get_all_tools() -> list[Tool]:
         Tool(
             name="start_activity",
             description="Start a new standalone Temporal activity execution",
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "activity": {"type": "string", "description": "Activity type name to start"},
@@ -129,7 +129,7 @@ def get_all_tools() -> list[Tool]:
         Tool(
             name="execute_activity",
             description="Execute a standalone Temporal activity and wait for result",
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "activity": {"type": "string", "description": "Activity type name to execute"},
@@ -144,7 +144,7 @@ def get_all_tools() -> list[Tool]:
         Tool(
             name="get_activity_result",
             description="Get the result of a standalone activity",
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "activity_id": {"type": "string", "description": "Standalone activity execution ID"},
@@ -157,7 +157,7 @@ def get_all_tools() -> list[Tool]:
         Tool(
             name="describe_activity",
             description="Get detailed information about a standalone activity execution",
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "activity_id": {"type": "string", "description": "Standalone activity execution ID"},
@@ -169,7 +169,7 @@ def get_all_tools() -> list[Tool]:
         Tool(
             name="list_activities",
             description="List standalone activity executions based on a query. Specify 'limit' to control results and 'skip' for pagination.",
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "query": {"type": "string", "description": "List filter query (e.g., 'TaskQueue = \"my-task-queue\"')"},
@@ -181,7 +181,7 @@ def get_all_tools() -> list[Tool]:
         Tool(
             name="count_activities",
             description="Count standalone activity executions matching a query",
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "query": {"type": "string", "description": "List filter query (e.g., 'TaskQueue = \"my-task-queue\"')"},
@@ -191,7 +191,7 @@ def get_all_tools() -> list[Tool]:
         Tool(
             name="cancel_activity",
             description="Cancel a running standalone activity execution",
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "activity_id": {"type": "string", "description": "Standalone activity execution ID"},
@@ -203,7 +203,7 @@ def get_all_tools() -> list[Tool]:
         Tool(
             name="terminate_activity",
             description="Forcefully terminate a standalone activity execution",
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "activity_id": {"type": "string", "description": "Standalone activity execution ID"},
@@ -216,7 +216,7 @@ def get_all_tools() -> list[Tool]:
         Tool(
             name="batch_signal",
             description="Send a signal to multiple workflows matching a query. Specify 'limit' to control batch size (default: 100).",
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "query": {"type": "string", "description": "Query to select workflows"},
@@ -230,7 +230,7 @@ def get_all_tools() -> list[Tool]:
         Tool(
             name="batch_cancel",
             description="Cancel multiple workflows matching a query with concurrent processing for speed. Use 'concurrency' to control parallel operations (default: 50).",
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "query": {"type": "string", "description": "Query to select workflows to cancel"},
@@ -243,7 +243,7 @@ def get_all_tools() -> list[Tool]:
         Tool(
             name="batch_terminate",
             description="Terminate multiple workflows matching a query. Specify 'limit' to control batch size (default: 100).",
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "query": {"type": "string", "description": "Query to select workflows to terminate"},
@@ -256,7 +256,7 @@ def get_all_tools() -> list[Tool]:
         Tool(
             name="batch_cancel_activities",
             description="Cancel multiple standalone activities matching a query with concurrent processing for speed. Use 'concurrency' to control parallel operations (default: 50).",
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "query": {"type": "string", "description": "Query to select activities to cancel"},
@@ -269,7 +269,7 @@ def get_all_tools() -> list[Tool]:
         Tool(
             name="batch_terminate_activities",
             description="Terminate multiple standalone activities matching a query. Specify 'limit' to control batch size (default: 100).",
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "query": {"type": "string", "description": "Query to select activities to terminate"},
@@ -283,7 +283,7 @@ def get_all_tools() -> list[Tool]:
         Tool(
             name="create_schedule",
             description="Create a new schedule for periodic workflow execution",
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "schedule_id": {"type": "string", "description": "Unique identifier for the schedule"},
@@ -298,7 +298,7 @@ def get_all_tools() -> list[Tool]:
         Tool(
             name="list_schedules",
             description="List all schedules. Specify 'limit' to control the number of results (default: 100). Use 'skip' to paginate through results.",
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "limit": {"type": "number", "description": "Maximum number of schedules to return (default: 100)"},
@@ -309,7 +309,7 @@ def get_all_tools() -> list[Tool]:
         Tool(
             name="pause_schedule",
             description="Pause a schedule",
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {"schedule_id": {"type": "string", "description": "The schedule ID to pause"}, "note": {"type": "string", "description": "Note explaining why the schedule was paused"}},
                 "required": ["schedule_id"],
@@ -318,7 +318,7 @@ def get_all_tools() -> list[Tool]:
         Tool(
             name="unpause_schedule",
             description="Resume a paused schedule",
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "schedule_id": {"type": "string", "description": "The schedule ID to unpause"},
@@ -330,22 +330,22 @@ def get_all_tools() -> list[Tool]:
         Tool(
             name="delete_schedule",
             description="Delete a schedule",
-            inputSchema={"type": "object", "properties": {"schedule_id": {"type": "string", "description": "The schedule ID to delete"}}, "required": ["schedule_id"]},
+            input_schema={"type": "object", "properties": {"schedule_id": {"type": "string", "description": "The schedule ID to delete"}}, "required": ["schedule_id"]},
         ),
         Tool(
             name="trigger_schedule",
             description="Manually trigger a scheduled workflow immediately",
-            inputSchema={"type": "object", "properties": {"schedule_id": {"type": "string", "description": "The schedule ID to trigger"}}, "required": ["schedule_id"]},
+            input_schema={"type": "object", "properties": {"schedule_id": {"type": "string", "description": "The schedule ID to trigger"}}, "required": ["schedule_id"]},
         ),
         Tool(
             name="describe_schedule",
             description="Get detailed configuration and runtime information about a schedule, including its spec, action, state, recent executions, and upcoming action times",
-            inputSchema={"type": "object", "properties": {"schedule_id": {"type": "string", "description": "The schedule ID to describe"}}, "required": ["schedule_id"]},
+            input_schema={"type": "object", "properties": {"schedule_id": {"type": "string", "description": "The schedule ID to describe"}}, "required": ["schedule_id"]},
         ),
         Tool(
             name="continue_as_new",
             description="Signal a workflow to continue as new (restart with new inputs while preserving history link)",
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "workflow_id": {"type": "string", "description": "The workflow ID to continue as new"},


### PR DESCRIPTION
## Summary
- migrate the low-level MCP server integration from removed 1.x decorators to MCP 2.x constructor callbacks
- return MCP 2.x result wrapper types for tool listing and tool calls
- update runtime dependency declarations to require mcp>=2.0.0

## Verification
- clean venv install from requirements resolves mcp 2.0.0 and confirms the old decorator methods are absent
- clean MCP 2.x pytest run: 87 passed
- smoke checked TemporalMCPServer tool listing returns 31 tools and serializes inputSchema correctly