### PR TITLE
ci: scan fork PR images with Docker Scout

### DIFF
--- a/.github/workflows/docker-scout-pr-build.yml
+++ b/.github/workflows/docker-scout-pr-build.yml
@@ -1,0 +1,66 @@
+name: Docker Scout PR Build
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-scout-pr-build-${{ github.event.pull_request.head.repo.full_name }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build-fork-pr-image:
+    name: Build fork PR image for Docker Scout
+    if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build image archive
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          outputs: type=docker,dest=/tmp/temporal-mcp-image.tar
+
+      - name: Write scan metadata
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('node:fs');
+            const path = require('node:path');
+            const outputDir = '/tmp/docker-scout-pr';
+            const sourceImage = '/tmp/temporal-mcp-image.tar';
+            const image = path.join(outputDir, 'temporal-mcp-image.tar');
+            const metadata = path.join(outputDir, 'metadata.json');
+            const pr = context.payload.pull_request;
+
+            fs.mkdirSync(outputDir, { recursive: true });
+            fs.renameSync(sourceImage, image);
+            fs.writeFileSync(metadata, JSON.stringify({
+              repository: context.repo.owner + '/' + context.repo.repo,
+              pr_number: pr.number,
+              head_sha: pr.head.sha,
+              head_repo: pr.head.repo.full_name,
+              head_branch: pr.head.ref,
+            }, null, 2) + '\n');
+
+      - name: Upload image archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-scout-pr-image
+          path: /tmp/docker-scout-pr/
+          retention-days: 1
+          compression-level: 0

--- a/.github/workflows/docker-scout-pr-scan.yml
+++ b/.github/workflows/docker-scout-pr-scan.yml
@@ -1,0 +1,265 @@
+name: Docker Scout PR Scan
+
+on:
+  workflow_run:
+    workflows:
+      - Docker Scout PR Build
+    types:
+      - completed
+
+permissions:
+  actions: read
+  checks: write
+  contents: read
+  security-events: write
+
+concurrency:
+  group: docker-scout-pr-scan-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  scan-fork-pr-image:
+    name: Scan fork PR image with Docker Scout
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.repository.full_name == github.repository && github.event.workflow_run.head_repository.full_name != github.repository }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    steps:
+      - name: Download PR image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: docker-scout-pr-image
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: docker-scout-pr
+
+      - name: Validate artifact files
+        run: |
+          test -f docker-scout-pr/metadata.json
+          test -f docker-scout-pr/temporal-mcp-image.tar
+          image_size=$(stat -c %s docker-scout-pr/temporal-mcp-image.tar)
+          max_size=$((2 * 1024 * 1024 * 1024))
+          if [ "$image_size" -gt "$max_size" ]; then
+            echo "::error::Docker image archive is too large: ${image_size} bytes"
+            exit 1
+          fi
+
+      - name: Resolve and verify PR metadata
+        id: pr
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('node:fs');
+            const metadata = JSON.parse(fs.readFileSync('docker-scout-pr/metadata.json', 'utf8'));
+            const run = context.payload.workflow_run;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const expectedRepository = `${owner}/${repo}`;
+            const requiredKeys = ['head_branch', 'head_repo', 'head_sha', 'pr_number', 'repository'];
+            const actualKeys = Object.keys(metadata);
+
+            for (const key of requiredKeys) {
+              if (!actualKeys.includes(key)) {
+                core.setFailed(`Missing metadata field: ${key}`);
+                return;
+              }
+            }
+
+            for (const key of actualKeys) {
+              if (!requiredKeys.includes(key)) {
+                core.setFailed(`Unexpected metadata field: ${key}`);
+                return;
+              }
+            }
+
+            if (typeof metadata.repository !== 'string' ||
+                typeof metadata.pr_number !== 'number' ||
+                typeof metadata.head_sha !== 'string' ||
+                typeof metadata.head_repo !== 'string' ||
+                typeof metadata.head_branch !== 'string') {
+              core.setFailed('Metadata fields have invalid types.');
+              return;
+            }
+
+            if (run.event !== 'pull_request') {
+              core.setFailed(`Unexpected workflow event: ${run.event}`);
+              return;
+            }
+
+            if (run.conclusion !== 'success') {
+              core.setFailed(`Source workflow did not complete successfully: ${run.conclusion}`);
+              return;
+            }
+
+            if (run.repository?.full_name !== expectedRepository) {
+              core.setFailed(`Workflow repository mismatch: ${run.repository?.full_name}`);
+              return;
+            }
+
+            if (run.head_repository?.full_name === expectedRepository) {
+              core.setFailed('This privileged scan path is only for fork pull requests.');
+              return;
+            }
+
+            let pr = (run.pull_requests || [])[0];
+            if (!pr) {
+              const headOwner = run.head_repository?.owner?.login;
+              if (headOwner && run.head_branch) {
+                const matches = await github.paginate(github.rest.pulls.list, {
+                  owner,
+                  repo,
+                  state: 'open',
+                  head: `${headOwner}:${run.head_branch}`,
+                  base: 'main',
+                  per_page: 100,
+                });
+                pr = matches.find((candidate) => candidate.head.sha === run.head_sha);
+              }
+            }
+
+            if (!pr) {
+              core.setFailed('No pull request could be resolved for this workflow run.');
+              return;
+            }
+
+            const { data: pull } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pr.number,
+            });
+
+            if (pull.state !== 'open') {
+              core.setFailed(`Pull request is not open: ${pull.state}`);
+              return;
+            }
+
+            if (pull.base.repo.full_name !== expectedRepository || pull.base.ref !== 'main') {
+              core.setFailed(`Unexpected pull request base: ${pull.base.repo.full_name}:${pull.base.ref}`);
+              return;
+            }
+
+            if (pull.head.sha !== run.head_sha) {
+              core.setFailed(`Pull request head SHA mismatch: ${pull.head.sha} != ${run.head_sha}`);
+              return;
+            }
+
+            if (pull.head.repo.full_name !== run.head_repository?.full_name) {
+              core.setFailed(`Pull request head repo mismatch: ${pull.head.repo.full_name} != ${run.head_repository?.full_name}`);
+              return;
+            }
+
+            if (metadata.repository !== expectedRepository) {
+              core.setFailed(`Artifact repository mismatch: ${metadata.repository}`);
+              return;
+            }
+
+            if (Number(metadata.pr_number) !== pr.number) {
+              core.setFailed(`Artifact PR mismatch: ${metadata.pr_number} != ${pr.number}`);
+              return;
+            }
+
+            if (metadata.head_sha !== run.head_sha) {
+              core.setFailed(`Artifact SHA mismatch: ${metadata.head_sha} != ${run.head_sha}`);
+              return;
+            }
+
+            if (metadata.head_repo !== pull.head.repo.full_name) {
+              core.setFailed(`Artifact head repo mismatch: ${metadata.head_repo} != ${pull.head.repo.full_name}`);
+              return;
+            }
+
+            if (metadata.head_branch !== pull.head.ref) {
+              core.setFailed(`Artifact head branch mismatch: ${metadata.head_branch} != ${pull.head.ref}`);
+              return;
+            }
+
+            core.setOutput('number', String(pr.number));
+            core.setOutput('head_sha', run.head_sha);
+
+      - name: Verify Docker Scout credentials
+        run: |
+          if [ -z "$DOCKERHUB_USERNAME" ] || [ -z "$DOCKERHUB_TOKEN" ]; then
+            echo "::error::Docker Scout requires DOCKERHUB_USERNAME and DOCKERHUB_TOKEN repository secrets."
+            echo "Create a Docker Hub access token and add both secrets, then rerun this workflow."
+            exit 1
+          fi
+
+      - name: Scan image archive with Docker Scout
+        id: scout
+        uses: docker/scout-action@v1
+        with:
+          command: cves
+          image: archive://${{ github.workspace }}/docker-scout-pr/temporal-mcp-image.tar
+          dockerhub-user: ${{ env.DOCKERHUB_USERNAME }}
+          dockerhub-password: ${{ env.DOCKERHUB_TOKEN }}
+          only-severities: critical,high
+          only-fixed: true
+          sarif-file: docker-scout.sarif.json
+          summary: true
+          exit-code: true
+          write-comment: false
+
+      - name: Upload Docker Scout SARIF
+        id: upload-sarif
+        if: ${{ always() && hashFiles('docker-scout.sarif.json') != '' }}
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: docker-scout.sarif.json
+          ref: refs/pull/${{ steps.pr.outputs.number }}/head
+          sha: ${{ steps.pr.outputs.head_sha }}
+
+      - name: Record Docker Scout PR check
+        if: ${{ always() && steps.pr.outputs.number != '' && steps.pr.outputs.head_sha != '' }}
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const conclusionByOutcome = {
+              success: 'success',
+              failure: 'failure',
+              cancelled: 'cancelled',
+              skipped: 'skipped',
+            };
+            const outcome = '${{ steps.scout.outcome }}';
+            const sarifOutcome = '${{ steps.upload-sarif.outcome }}';
+            const conclusion = outcome === 'success' && sarifOutcome === 'failure'
+              ? 'failure'
+              : conclusionByOutcome[outcome] || 'failure';
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'Docker Scout PR Scan',
+              head_sha: '${{ steps.pr.outputs.head_sha }}',
+              status: 'completed',
+              conclusion,
+              details_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              output: {
+                title: 'Docker Scout PR Scan',
+                summary: conclusion === 'success'
+                  ? 'Docker Scout completed successfully for the fork PR image archive.'
+                  : 'Docker Scout or SARIF upload did not complete successfully. Open the workflow run for details.',
+              },
+            });
+
+      - name: Write comment metadata
+        if: ${{ always() && steps.pr.outputs.number != '' && steps.pr.outputs.head_sha != '' }}
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('node:fs');
+            fs.mkdirSync('docker-scout-pr-result', { recursive: true });
+            fs.writeFileSync('docker-scout-pr-result/metadata.json', JSON.stringify({
+              repository: context.repo.owner + '/' + context.repo.repo,
+              pr_number: Number('${{ steps.pr.outputs.number }}'),
+              head_sha: '${{ steps.pr.outputs.head_sha }}',
+            }, null, 2) + '\n');
+
+      - name: Upload comment metadata
+        if: ${{ always() && hashFiles('docker-scout-pr-result/metadata.json') != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-scout-pr-result
+          path: docker-scout-pr-result/metadata.json
+          retention-days: 1

--- a/.github/workflows/docker-scout.yml
+++ b/.github/workflows/docker-scout.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   scan-container:
     name: Scan container image
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:

--- a/.github/workflows/security-pr-comment.yml
+++ b/.github/workflows/security-pr-comment.yml
@@ -4,6 +4,8 @@ on:
   workflow_run:
     workflows:
       - Docker Scout
+      - Docker Scout PR Build
+      - Docker Scout PR Scan
       - CodeQL
       - OSV-Scanner
     types:
@@ -23,19 +25,49 @@ concurrency:
 jobs:
   update-comment:
     name: Update security scan comment
-    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    # Direct scanners are triggered by pull_request. The privileged fork-PR Scout
+    # scan is triggered by workflow_run, so admit it by trusted workflow path.
+    if: ${{ github.event.workflow_run.event == 'pull_request' || github.event.workflow_run.path == '.github/workflows/docker-scout-pr-scan.yml' }}
     runs-on: ubuntu-latest
 
     steps:
+      - name: Download Docker Scout PR result metadata
+        id: download-scout-result
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: docker-scout-pr-result
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: docker-scout-pr-result
+
       - name: Update PR comment
         uses: actions/github-script@v8
         with:
           script: |
+            const fs = require('node:fs');
             const marker = '<!-- temporal-mcp-security-summary -->';
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const run = context.payload.workflow_run;
-            let pr = run.pull_requests[0];
+            let scoutPrResult = null;
+            const scoutResultDownloadOutcome = '${{ steps.download-scout-result.outcome }}';
+            if (run.path === '.github/workflows/docker-scout-pr-scan.yml' && scoutResultDownloadOutcome === 'failure') {
+              core.warning('Docker Scout PR Scan result metadata artifact was unavailable; falling back to workflow metadata.');
+            }
+            try {
+              if (fs.existsSync('docker-scout-pr-result/metadata.json')) {
+                scoutPrResult = JSON.parse(fs.readFileSync('docker-scout-pr-result/metadata.json', 'utf8'));
+              }
+            } catch (error) {
+              core.warning(`Failed to parse Docker Scout PR result metadata: ${error.message}`);
+              scoutPrResult = null;
+            }
+            let pr = (run.pull_requests || [])[0];
+
+            if (!pr && scoutPrResult?.pr_number) {
+              pr = { number: scoutPrResult.pr_number };
+            }
 
             if (!pr) {
               const headOwner = run.head_repository?.owner?.login;
@@ -64,7 +96,7 @@ jobs:
               pull_number: prNumber,
             });
 
-            const headSha = pull.head.sha || run.head_sha || '';
+            const headSha = scoutPrResult?.head_sha || pull.head.sha || run.head_sha || '';
             const shortSha = headSha ? headSha.slice(0, 7) : 'unknown';
             const runUrl = run.html_url;
 
@@ -140,7 +172,7 @@ jobs:
               {
                 key: 'scout',
                 title: 'Docker Scout',
-                check: newestMatching(/Docker Scout/i, /Scan container image/i),
+                check: newestMatching(/Docker Scout PR Scan/i, /Docker Scout/i, /Scan container image/i, /Scan fork PR image/i),
                 toolPatterns: [/docker scout/i, /scout/i],
                 usesCodeScanning: true,
                 success: 'No open critical/high fixable container CVEs reported for this PR ref.',
@@ -214,7 +246,7 @@ jobs:
                 if (tool.check?.conclusion === 'success') return tool.success;
                 if (tool.check?.conclusion === 'skipped') return 'Scan was skipped.';
                 if (!tool.check) return 'Waiting for this scan to report.';
-                return 'No matching open code scanning alerts found for this PR ref.';
+                return 'Check did not complete successfully; open details for output.';
               }
 
               const bySeverity = alerts.reduce((counts, alert) => {


### PR DESCRIPTION
## Summary
- add an untrusted fork-PR Docker image build workflow with no secrets
- add a privileged workflow_run Docker Scout scan that downloads and scans the image archive with Docker Hub credentials
- keep direct Docker Scout scanning for push, schedule, and same-repo PRs only
- update the consolidated security PR comment to include the two-phase Docker Scout PR scan

## Safety model
- fork PR code only runs in Docker Scout PR Build, which has contents:read permissions and no repository secrets
- the untrusted build uploads only an image archive plus JSON metadata
- the privileged scan does not checkout PR code and does not run files from the artifact
- the privileged scan validates repository, PR number, base branch, head repo, head branch, and head SHA before using Docker Hub credentials
- the privileged scan uses Docker Scout against archive://, not docker run
- fork PR build cache is disabled to avoid shared-cache trust ambiguity

## Reporting
- fork PR Docker Scout scans create a check on the PR head SHA
- SARIF is uploaded against refs/pull/<n>/head when produced
- the existing Security Scan Results bot comment includes Docker Scout PR Scan results

## Validation
- YAML parsed for changed workflows
- embedded github-script JavaScript passed node --check
- git diff --check passed
- architect subagent reviewed the threat model and acceptance criteria
- reviewer subagent reviewed the hardened implementation; no blocking security/correctness issues remained

## Notes
- actionlint is not installed in the local environment, so it was not run
- after merge, validate with a real fork PR to confirm artifact handoff, archive:// Scout scanning, SARIF association, and comment update behavior