### PR TITLE
fix: resolve container scan findings

### DIFF
--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -26,4 +26,4 @@ jobs:
   scan-scheduled:
     name: Scan dependencies
     if: github.event_name == 'push' || github.event_name == 'schedule'
-    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.8
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.5.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,13 @@ ENV PATH="/opt/venv/bin:$PATH"
 # Upgrade packaging tools before dependency install
 RUN pip install --no-cache-dir --upgrade "pip>=26.0" "wheel>=0.46.2" "setuptools>=75.0"
 RUN pip install --no-cache-dir -r requirements.txt
+RUN pip uninstall --yes pip setuptools wheel
 
 FROM python:3.14-alpine AS runtime
 
 WORKDIR /app
+
+RUN python -m pip uninstall --yes pip
 
 RUN apk add --no-cache \
     libgcc \


### PR DESCRIPTION
## Summary
- remove build-only packaging tools from the application virtual environment
- remove the base image's system pip installation from the runtime stage
- update scheduled OSV scanning to v2.5.0

## Verification
- built the updated container image successfully
- verified application runtime imports and CLI startup
- scanned the final image with Docker Scout: 0 critical, high, medium, or low vulnerabilities
- verified Dependabot alerts and security updates are enabled for the repository